### PR TITLE
flexiblere Antragsnummerierung

### DIFF
--- a/protected/models/Aenderungsantrag.php
+++ b/protected/models/Aenderungsantrag.php
@@ -419,16 +419,17 @@ class Aenderungsantrag extends IAntrag
 	public function naechsteAenderungsRevNr()
 	{
 		$max_rev = 0;
-		if ($this->antrag->veranstaltung->getEinstellungen()->ae_nummerierung_nach_zeile) {
+		$einstellungen = $this->antrag->veranstaltung->getEinstellungen();
+		if ($einstellungen->ae_nummerierung_nach_zeile) {
 			$line        = $this->getFirstDiffLine();
-			$ae_rev_base = $this->antrag->revision_name . "-Ä" . $line . "-";
+			$ae_rev_base = $this->antrag->revision_name . "-" . $einstellungen->ae_praefix . str_pad ($line,$einstellungen->ae_ziffern,'0',STR_PAD_LEFT) . "-";
 			$max_rev     = 0;
 			foreach ($this->antrag->aenderungsantraege as $ae) {
 				$x = explode($ae_rev_base, $ae->revision_name);
 				if (count($x) == 2 && $x[1] > $max_rev) $max_rev = IntVal($x[1]);
 			}
 			return $ae_rev_base . ($max_rev + 1);
-		} elseif ($this->antrag->veranstaltung->getEinstellungen()->ae_nummerierung_global) {
+		} elseif ($einstellungen->ae_nummerierung_global) {
 			$antraege = $this->antrag->veranstaltung->antraege;
 			foreach ($antraege as $ant) {
 				$m = $ant->getMaxAenderungsRevNr();
@@ -437,7 +438,7 @@ class Aenderungsantrag extends IAntrag
 		} else {
 			$max_rev = $this->antrag->getMaxAenderungsRevNr();
 		}
-		return "Ä" . ($max_rev + 1);
+		return $einstellungen->ae_praefix . ($max_rev + 1);
 	}
 
 	/**

--- a/protected/models/VeranstaltungsEinstellungen.php
+++ b/protected/models/VeranstaltungsEinstellungen.php
@@ -16,6 +16,8 @@ class VeranstaltungsEinstellungen extends CFormModel
 	public $zeilen_nummerierung_global = false;
 	public $ae_nummerierung_global = false;
 	public $ae_nummerierung_nach_zeile = false;
+	public $ae_praefix = "Ä";
+	public $ae_ziffern = "1";
 	public $revision_name_verstecken = false;
 	public $ansicht_minimalistisch = false;
 	public $feeds_anzeigen = true;

--- a/protected/views/admin/veranstaltungen/update.php
+++ b/protected/views/admin/veranstaltungen/update.php
@@ -278,6 +278,29 @@ $einstellungen = $model->getEinstellungen();
 			</small>
 		</label>
 	</div>
+	<div>
+		<label style="display: inline;" id="ae_ziffern">
+			<br>
+			<input type="hidden" name="VeranstaltungsEinstellungen[einstellungsfelder][]" value="ae_ziffern">
+			<input type="number" name="VeranstaltungsEinstellungen[ae_ziffern]" min="1" max="9" value="<?php echo isset ($einstellungen->ae_ziffern) ? $einstellungen->ae_ziffern : "1"; ?>">
+			<strong>Ziffernanzahl</strong> für Zeilennummern in Änderungsantragskürzeln
+			</label>
+		</div>
+	<div>
+		<label style="display: inline;">
+			<input type="hidden" name="VeranstaltungsEinstellungen[einstellungsfelder][]" value="ae_praefix">
+			<input type="text" name="VeranstaltungsEinstellungen[ae_praefix]" value="<?php echo isset ($einstellungen->ae_praefix) ? $einstellungen->ae_praefix : "Ä"; ?>">
+			<strong>Präfix</strong> für Änderungsantragskürzel (z.B. "Ä")
+		</label>
+	</div>
+	<script>
+		$(function () {
+			$("input[name='VeranstaltungsEinstellungen[ae_nummerierung]']").change(function () {
+				if ($(this).prop("value") == "2") $("#ae_ziffern").show();
+				else $("#ae_ziffern").hide();
+			}).trigger("change");
+		})
+	</script>
 	<br>
 
 </div>

--- a/protected/views/admin/veranstaltungen/update.php
+++ b/protected/views/admin/veranstaltungen/update.php
@@ -296,7 +296,7 @@ $einstellungen = $model->getEinstellungen();
 	<script>
 		$(function () {
 			$("input[name='VeranstaltungsEinstellungen[ae_nummerierung]']").change(function () {
-				if ($(this).prop("value") == "2") $("#ae_ziffern").show();
+				if (($(this).prop("value") == "2") == $(this).prop ("checked")) $("#ae_ziffern").show();
 				else $("#ae_ziffern").hide();
 			}).trigger("change");
 		})


### PR DESCRIPTION
Setzt #46 um. Zeilennummern können links mit Nullen gepadded werden;
statt „Ä“ kann ein beliebiges (ggf. leeres) Präfix für Änderungsanträge angegeben
werden.