### PR TITLE
ÄnderungsantragstellerInnen anzeigen

### DIFF
--- a/protected/models/Aenderungsantrag.php
+++ b/protected/models/Aenderungsantrag.php
@@ -524,6 +524,14 @@ class Aenderungsantrag extends IAntrag
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getKurzform ()
+	{
+		return ($this->revision_name != "" ? $this->revision_name : $this->id) . ": " . $this->getAntragstellerInnen () [0]->getNameMitOrga ();
+	}
+	
+	/**
 	 * @return bool
 	 */
 	public function binInitiatorIn()

--- a/protected/views/antrag/anzeige.php
+++ b/protected/views/antrag/anzeige.php
@@ -346,7 +346,7 @@ if ($text2name && trim($antrag->text2)) {
 				/** @var Aenderungsantrag $ant */
 				foreach ($abs->aenderungsantraege as $ant) {
 					$ae_link = $this->createUrl("aenderungsantrag/anzeige", array("veranstaltung_id" => $ant->antrag->veranstaltung->url_verzeichnis, "antrag_id" => $ant->antrag->id, "aenderungsantrag_id" => $ant->id));
-					echo "<li class='aenderungsantrag' data-first-line='" . $ant->getFirstAffectedLineOfParagraph_absolute($i, $absae) . "'><a class='aender_link' data-id='" . $ant->id . "' href='" . CHtml::encode($ae_link) . "'>" . CHtml::encode($ant->revision_name) . "</a></li>\n";
+					echo "<li class='aenderungsantrag' data-first-line='" . $ant->getFirstAffectedLineOfParagraph_absolute($i, $absae) . "'><a class='aender_link' data-id='" . $ant->id . "' href='" . CHtml::encode($ae_link) . "'>" . CHtml::encode($ant->getKurzform ()) . "</a></li>\n";
 				} ?>
 			</ul>
 
@@ -588,9 +588,7 @@ if (count($aenderungsantraege) > 0 || $antrag->veranstaltung->policy_aenderungsa
 			echo CHtml::openTag('ul', array("class" => "aenderungsantraege"));
 			foreach ($aenderungsantraege as $relatedModel) {
 				echo CHtml::openTag('li');
-				$aename = $relatedModel->revision_name;
-				if ($aename == "") $aename = $relatedModel->id;
-				echo CHtml::link($aename, $this->createUrl("aenderungsantrag/anzeige", array("antrag_id" => $antrag->id, "aenderungsantrag_id" => $relatedModel->id)));
+				echo CHtml::link($relatedModel->getKurzform (), $this->createUrl("aenderungsantrag/anzeige", array("antrag_id" => $antrag->id, "aenderungsantrag_id" => $relatedModel->id)));
 				echo " (" . CHtml::encode(Aenderungsantrag::$STATI[$relatedModel->status]) . ")";
 				echo CHtml::closeTag('li');
 			}


### PR DESCRIPTION
resolves #43
In der Antragsanzeige werden sowohl rechts am Rand als auch unter dem Antrag zusätzlich zu den Antragskürzeln auch die ÄnderungsantragstellerInnen (mit Gliederung) angezeigt. Bei mir sieht das so aus:

![anderungen mit antragstellerin](https://cloud.githubusercontent.com/assets/1418717/6820428/3f79b360-d2cf-11e4-8126-47867d174997.png)
