### PR TITLE
PDF-Antrags-Einleitung speicherbar machen

### DIFF
--- a/protected/views/admin/veranstaltungen/update.php
+++ b/protected/views/admin/veranstaltungen/update.php
@@ -129,6 +129,7 @@ $einstellungen = $model->getEinstellungen();
 	</div>
 
 	<div>
+		<input type="hidden" name="VeranstaltungsEinstellungen[einstellungsfelder][]" value="antrag_einleitung">
 		<?php echo $form->labelEx($einstellungen, 'antrag_einleitung', array("label" => "PDF-Antrags-Einleitung")); ?>
 		<div class="std_content_col">
 			<?php echo $form->textArea($einstellungen, 'antrag_einleitung'); ?>


### PR DESCRIPTION
hidden input für PDF-Antrags-Einleitung fehlte, so daß sie nicht gespeichert wurde