### PR TITLE
ad-hoc fix für das Problem der verschwindenden Zeilen

### DIFF
--- a/components/diff/AmendmentSectionFormatter.php
+++ b/components/diff/AmendmentSectionFormatter.php
@@ -124,6 +124,8 @@ class AmendmentSectionFormatter
     {
         $inIns          = $inDel = false;
         $affectedBlocks = [];
+        $interveningCount = 0;
+        $lastBlock = null;
         foreach ($blocks as $block) {
             $hadDiff = false;
             if ($inIns) {
@@ -153,22 +155,30 @@ class AmendmentSectionFormatter
                     }
                 }
             }
+            $addBlock = function () use ($block,&$affectedBlocks,$lastBlock,&$interveningCount) {
+                if ($interveningCount == 2)
+                    $affectedBlocks[] = $lastBlock;
+                $affectedBlocks[] = $block;
+                $interveningCount = 0;
+            };
             if ($inIns) {
                 $block['text']    = $block['text'] . '</ins>';
-                $affectedBlocks[] = $block;
+                $addBlock ();
             } elseif ($inDel) {
                 $block['text']    = $block['text'] . '</del>';
-                $affectedBlocks[] = $block;
+                $addBlock ();
             } elseif ($hadDiff) {
-                $affectedBlocks[] = $block;
+                $addBlock ();
             } else {
                 if (preg_match('/<(ul|ol) class="inserted">.*<\/(ul|ol)>/siu', $block['text'])) {
-                    $affectedBlocks[] = $block;
+                    $addBlock ();
                 }
                 if (preg_match('/<(ul|ol) class="deleted">.*<\/(ul|ol)>/siu', $block['text'])) {
-                    $affectedBlocks[] = $block;
+                    $addBlock ();
                 }
             }
+            $interveningCount++;
+            $lastBlock = $block;
         }
         return $affectedBlocks;
     }

--- a/components/diff/AmendmentSectionFormatter.php
+++ b/components/diff/AmendmentSectionFormatter.php
@@ -155,30 +155,33 @@ class AmendmentSectionFormatter
                     }
                 }
             }
-            $addBlock = function () use ($block,&$affectedBlocks,$lastBlock,&$interveningCount) {
-                if ($interveningCount == 2)
+            $addBlock = false;
+            if ($inIns) {
+                $block['text']    = $block['text'] . '</ins>';
+                $addBlock = true;
+            } elseif ($inDel) {
+                $block['text']    = $block['text'] . '</del>';
+                $addBlock = true;
+            } elseif ($hadDiff) {
+                $addBlock = true;
+            } else {
+                if (preg_match('/<(ul|ol) class="inserted">.*<\/(ul|ol)>/siu', $block['text'])) {
+                    $addBlock = true;
+                }
+                if (preg_match('/<(ul|ol) class="deleted">.*<\/(ul|ol)>/siu', $block['text'])) {
+                    $addBlock = true;
+                }
+            }
+            if ($addBlock) {
+                if ($interveningCount == 1)
                     $affectedBlocks[] = $lastBlock;
                 $affectedBlocks[] = $block;
                 $interveningCount = 0;
-            };
-            if ($inIns) {
-                $block['text']    = $block['text'] . '</ins>';
-                $addBlock ();
-            } elseif ($inDel) {
-                $block['text']    = $block['text'] . '</del>';
-                $addBlock ();
-            } elseif ($hadDiff) {
-                $addBlock ();
-            } else {
-                if (preg_match('/<(ul|ol) class="inserted">.*<\/(ul|ol)>/siu', $block['text'])) {
-                    $addBlock ();
-                }
-                if (preg_match('/<(ul|ol) class="deleted">.*<\/(ul|ol)>/siu', $block['text'])) {
-                    $addBlock ();
-                }
             }
-            $interveningCount++;
-            $lastBlock = $block;
+            else {
+                $interveningCount++;
+                $lastBlock = $block;
+            }
         }
         return $affectedBlocks;
     }

--- a/components/diff/AmendmentSectionFormatter.php
+++ b/components/diff/AmendmentSectionFormatter.php
@@ -124,7 +124,7 @@ class AmendmentSectionFormatter
     {
         $inIns          = $inDel = false;
         $affectedBlocks = [];
-        $interveningCount = 0;
+        $interveningCount = 2;
         $lastBlock = null;
         foreach ($blocks as $block) {
             $hadDiff = false;


### PR DESCRIPTION
Das Problem der verschwindenen Zeilen, das Solveig gemeldet hat, entstand dadurch, dass erst nur betroffene Zeilen rausgesucht wurden, diese dann aber wenn eine einzige unbetroffene Zeile dazwischen ist zu Blöcken zusammengelegt wurden, in denen die unbetroffene Zeile dazwischen fehlte. Ich habe das ad hoc dadurch gelöst, daß einzelne unbetroffene Zeilen als betroffene behandelt werden; möglicherweise gibt es langfristig eine bessere Lösung.