### PR TITLE
Organisationen fehlten als Antragstellerinnen in PDFs

### DIFF
--- a/models/db/Amendment.php
+++ b/models/db/Amendment.php
@@ -624,7 +624,7 @@ class Amendment extends IMotion implements IRSSItem
         if (count($inits) == 1) {
             $first = $inits[0];
             if ($first->personType == MotionSupporter::PERSON_ORGANIZATION && $first->resolutionDate > 0) {
-                $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->name;
+                $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->organization;
                 $return[\Yii::t('pdf', 'ResolutionDate')]  = Tools::formatMysqlDate($first->resolutionDate);
             } else {
                 $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->getNameWithResolutionDate(false);

--- a/models/db/Motion.php
+++ b/models/db/Motion.php
@@ -650,7 +650,7 @@ class Motion extends IMotion implements IRSSItem
         if (count($inits) == 1) {
             $first = $inits[0];
             if ($first->personType == MotionSupporter::PERSON_ORGANIZATION && $first->resolutionDate > 0) {
-                $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->name;
+                $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->organization;
                 $return[\Yii::t('pdf', 'ResolutionDate')]  = Tools::formatMysqlDate($first->resolutionDate);
             } else {
                 $return[\Yii::t('pdf', 'InitiatorSingle')] = $first->getNameWithResolutionDate(false);


### PR DESCRIPTION
Beim Nachvollziehen dieses Bugs fiel mir auf, daß die Antragsteller*innen anscheinend dreimal ausgelesen werden, wenn ein Antrags-PDF erzeugt wird -- einmal an der hier geänderten Stelle, aber davor schon zweimal, einmal in views/motion/pdf_tex.php (`$layout->author  = $motion->getInitiatorsStr()`) und einmal in views/motion/LayoutHelper::renderTeX (`$initiators` wird mit `$motion->getInitiators ()` gefüllt) (bzw. in den entsprechenden Dateien in views/amendment). Diese Antragsteller*innen werden aber anscheinend gar nicht verwendet. Ich überblicke nicht, wofür dieser Code sonst noch verwendet wird, aber vielleicht könnte man diese Abfragen einsparen.