### PR TITLE
ad hoc reordering for board elections BDK Halle 2015

### DIFF
--- a/components/MotionSorter.php
+++ b/components/MotionSorter.php
@@ -77,9 +77,12 @@ class MotionSorter
     public static function getSortedMotionsSort($prefix1, $prefix2)
     {
         // ad hoc reordering for board elections BDK Halle 2015
-        if ($prefix1 [0] == 'W' && $prefix2 [0] == 'W' && $prefix1 [1] != $prefix2 [1]) {
-            $order = ['V' => 0, 'P' => 1, 'S' => 2, 'B' => 3];
-            return $order [$prefix1 [1]] - $order [$prefix2 [1]];
+        $initial1 = substr ($prefix1,0,3);
+        $initial2 = substr ($prefix2,0,3);
+        if ($initial1 != $initial2) {
+            $order = ['WV-' => 1, 'WPG' => 2, 'WBS' => 3, 'WB-' => 4];
+            if ($order [$initial1] && $order [$initial2])
+                return $order [$initial1] - $order [$initial2];
         }
 
         if ($prefix1 == '' && $prefix2 == '') {

--- a/components/MotionSorter.php
+++ b/components/MotionSorter.php
@@ -76,6 +76,12 @@ class MotionSorter
      */
     public static function getSortedMotionsSort($prefix1, $prefix2)
     {
+        // ad hoc reordering for board elections BDK Halle 2015
+        if ($prefix1 [0] == 'W' && $prefix2 [0] == 'W' && $prefix1 [1] != $prefix2 [1]) {
+            $order = ['V' => 0, 'P' => 1, 'S' => 2, 'B' => 3];
+            return $order [$prefix1 [1]] - $order [$prefix2 [1]];
+        }
+
         if ($prefix1 == '' && $prefix2 == '') {
             return 0;
         }


### PR DESCRIPTION
Gerhard fragte, ob man für den TOP BuVo-Wahlen die Reihenfolge der Anträge von Hand ändern kann, damit sie in der Reihenfolge der Wahl stehen (Vorsitzende, Politische Geschäftsführung, Schatzmeister\*in, Beisitzer\*innen). Ich hab mal diese ad-hoc-Umsortierung geschrieben -- ich weiß nicht, ob Du sie in v3 übernehmen möchtest und nachher wieder rauswerfen, oder vielleicht besser nur den Code auf dem Server ändern? Oder wenn Du es gleich längerfristig lösen möchtest, könnte man Admins optional einen Sortier-Key angeben lassen, der vom Präfix abweichen kann. Ich glaube, wir brauchen da kein komfortables UI mit hoch- und runterschieben oder so, weil es so selten vorkommt.