### PR TITLE
flush cache on edit

### DIFF
--- a/controllers/AmendmentController.php
+++ b/controllers/AmendmentController.php
@@ -269,6 +269,7 @@ class AmendmentController extends Base
         $form     = new AmendmentEditForm($amendment->motion, $amendment);
 
         if (isset($_POST['save'])) {
+            $amendment->flushCacheWithChildren();
             $form->setAttributes([$_POST, $_FILES]);
             try {
                 $form->saveAmendment($amendment);

--- a/controllers/MotionController.php
+++ b/controllers/MotionController.php
@@ -304,6 +304,7 @@ class MotionController extends Base
         $fromMode = ($motion->status == Motion::STATUS_DRAFT ? 'create' : 'edit');
 
         if (isset($_POST['save'])) {
+            $motion->flushCacheWithChildren();
             $form->setAttributes([$_POST, $_FILES]);
             try {
                 $form->saveMotion($motion);


### PR DESCRIPTION
Wenn man einen Änderungsantrag schreibt und dann "korrigiert", wurde trotzdem das vorherige Diff aus dem Cache angezeigt. Bei eigenständigen Anträgen hab ich keine konkreten Auswirkungen gesehen, hab aber da auch einen cache flush eingefügt, weil auch da vermutlich der Cache beim Edit ungültig wird.