### PR TITLE
deletion beyond list was being dropped

### DIFF
--- a/components/diff/Diff.php
+++ b/components/diff/Diff.php
@@ -183,9 +183,11 @@ class Diff
         $return = [];
 
         $preOp        = null;
+        $preList      = false;
         $currentSpool = [];
         foreach ($operations as $operation) {
             $firstfour = mb_substr($operation[0], 0, 4);
+            $isList = $firstfour == '<ul>' || $firstfour == '<ol>';
             if ($operation[0] == static::ORIG_LINEBREAK || preg_match('/^<[^>]*>$/siu', $operation[0])) {
                 if (count($currentSpool) > 0) {
                     $return[] = [
@@ -199,7 +201,7 @@ class Diff
                 ];
                 $preOp        = null;
                 $currentSpool = [];
-            } elseif ($operation[1] !== $preOp || $firstfour == '<ul>' || $firstfour == '<ol>') {
+            } elseif ($operation[1] !== $preOp || $isList || $preList) {
                 if (count($currentSpool) > 0) {
                     $return[] = [
                         implode($groupBy, $currentSpool),
@@ -211,6 +213,7 @@ class Diff
             } else {
                 $currentSpool[] = $operation[0];
             }
+            $preList = $isList;
         }
         if (count($currentSpool) > 0) {
             $return[] = [


### PR DESCRIPTION
In `components\diff\Diff::groupOperations` werden list items gesondert behandelt, aber wenn nach dem Ende der Liste weitere Elemente ebenfalls gelöscht oder ebenfalls eingefügt werden, wurden die an den letzten list item rangehängt, mit der Folge, dass dann in `components\diff\Diff::wrapWithDelete` das Ganze als list item behandelt wurde und einfach nur `class="delete"` reingesetzt wurde, anstatt es in `<del></del>` einzuschließen. Ich hab es so geändert, dass das Akkumulieren der Gruppe nicht nur beendet wird, wenn ein list item kommt, sondern auch wenn ein list item voranging.