### PR TITLE
ZIP-Archiv der PDFs aller Anträge bzw. Änderungsanträge

### DIFF
--- a/components/latex/Exporter.php
+++ b/components/latex/Exporter.php
@@ -3,6 +3,8 @@
 namespace app\components\latex;
 
 use app\components\HTMLTools;
+use app\models\db\Amendment;
+use app\models\db\Motion;
 use app\models\exceptions\Internal;
 use app\models\settings\AntragsgruenApp;
 
@@ -363,5 +365,47 @@ class Exporter
         }
 
         return $pdf;
+    }
+
+    /**
+     * @param $motion Motion
+     */
+    public static function createMotionPdf ($motion) {
+        $texTemplate = $motion->motionType->texTemplate;
+
+        $layout            = new Layout();
+        $layout->assetRoot = \yii::$app->basePath . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
+        //$layout->templateFile = \yii::$app->basePath . DIRECTORY_SEPARATOR .
+        //    'assets' . DIRECTORY_SEPARATOR . 'motion_std.tex';
+        $layout->template = $texTemplate->texLayout;
+        $layout->author   = $motion->getInitiatorsStr();
+        $layout->title    = $motion->getTitleWithPrefix();
+
+        /** @var AntragsgruenApp $params */
+        $params   = \yii::$app->params;
+        $exporter = new Exporter($layout, $params);
+        $content  = \app\views\motion\LayoutHelper::renderTeX($motion, $exporter);
+        return $exporter->createPDF([$content]);
+    }
+
+    /**
+     * @param $amendment Amendment
+     */
+    public static function createAmendmentPdf ($amendment) {
+        $texTemplate = $amendment->getMyMotion()->motionType->texTemplate;
+
+        $layout            = new Layout();
+        $layout->assetRoot = \yii::$app->basePath . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
+        //$layout->templateFile = \yii::$app->basePath . DIRECTORY_SEPARATOR .
+        //    'assets' . DIRECTORY_SEPARATOR . 'motion_std.tex';
+        $layout->template = $texTemplate->texLayout;
+        $layout->author   = $amendment->getInitiatorsStr();
+        $layout->title    = $amendment->getTitle();
+
+        /** @var AntragsgruenApp $params */
+        $params = \yii::$app->params;
+        $exporter = new Exporter($layout, $params);
+        $content = \app\views\amendment\LayoutHelper::renderTeX($amendment);
+        return $exporter->createPDF([$content]);
     }
 }

--- a/config/urls.php
+++ b/config/urls.php
@@ -18,8 +18,8 @@ $userPaths   = 'login|logout|confirmregistration|loginbyredirecttoken|loginwurze
 $userPaths .= '|consultationaccesserror|myaccount|emailchange';
 $domPlainPaths = 'legal|privacy|help|password|billing|createsite|savetextajax|siteconfig|antragsgrueninit';
 $domPlainPaths .= '|antragsgrueninitdbtest';
-$adminMotionPaths    = 'index|type|typecreate|listall|excellist|odslist|odslistall|openslides';
-$adminAmendmentPaths = 'index|excellist|odslist|pdflist|openslides';
+$adminMotionPaths    = 'index|type|typecreate|listall|excellist|odslist|pdfziplist|odslistall|openslides';
+$adminAmendmentPaths = 'index|excellist|odslist|pdflist|pdfziplist|openslides';
 $adminPaths          = 'consultation|consultationextended|translation|siteaccess|siteconsultations|openslidesusers';
 
 $urlRules = [

--- a/controllers/admin/AmendmentController.php
+++ b/controllers/admin/AmendmentController.php
@@ -38,7 +38,19 @@ class AmendmentController extends AdminBase
         return $this->render('pdf_list', ['consultation' => $this->consultation]);
     }
 
+    /**
+     * @return string
+     */
+    public function actionPdfziplist()
+    {
+        \yii::$app->response->format = Response::FORMAT_RAW;
+        \yii::$app->response->headers->add('Content-Type', 'application/zip');
+        \yii::$app->response->headers->add('Content-Disposition', 'attachment;filename=amendments.zip');
+        \yii::$app->response->headers->add('Cache-Control', 'max-age=0');
 
+        return $this->renderPartial('pdf_zip_list', ['consultation' => $this->consultation]);
+    }
+    
     /**
      * @param int $amendmentId
      * @return string

--- a/controllers/admin/MotionController.php
+++ b/controllers/admin/MotionController.php
@@ -357,4 +357,17 @@ class MotionController extends AdminBase
             'motions' => $motions,
         ]);
     }
+
+    /**
+     * @return string
+     */
+    public function actionPdfziplist()
+    {
+        \yii::$app->response->format = Response::FORMAT_RAW;
+        \yii::$app->response->headers->add('Content-Type', 'application/zip');
+        \yii::$app->response->headers->add('Content-Disposition', 'attachment;filename=motions.zip');
+        \yii::$app->response->headers->add('Cache-Control', 'max-age=0');
+
+        return $this->renderPartial('pdf_zip_list', ['consultation' => $this->consultation]);
+    }
 }

--- a/messages/de/admin.php
+++ b/messages/de/admin.php
@@ -20,6 +20,7 @@ return [
     'index_amendments'            => 'Änderungsanträge',
     'index_pdf_collection'        => 'Sammel-PDF',
     'index_pdf_list'              => 'Liste aller PDFs',
+    'index_pdf_zip_list'          => 'ZIP-Archiv aller PDFs',
     'index_settings'              => 'Einstellungen',
     'index_consultation_settings' => 'Diese Veranstaltung / Programmdiskussion',
     'index_motion_types'          => 'Antragstypen bearbeiten',

--- a/messages/en/admin.php
+++ b/messages/en/admin.php
@@ -20,6 +20,7 @@ return [
     'index_amendments'            => 'Amendments',
     'index_pdf_collection'        => 'All-In-One-PDF',
     'index_pdf_list'              => 'List of all PDFs',
+    'index_pdf_zip_list'          => 'ZIP archive of all PDFs',
     'index_settings'              => 'Settings',
     'index_consultation_settings' => 'This Consultation',
     'index_motion_types'          => 'Edit motion types',

--- a/views/admin/amendment/pdf_zip_list.php
+++ b/views/admin/amendment/pdf_zip_list.php
@@ -1,0 +1,34 @@
+<?php
+
+use app\components\latex\Exporter;
+use app\components\UrlHelper;
+
+/**
+ * @var $this yii\web\View
+ * @var array $items
+ */
+
+/** @var \app\controllers\Base $controller */
+$controller   = $this->context;
+$consultation = $controller->consultation;
+
+/** @var \app\models\settings\AntragsgruenApp $params */
+$params = \yii::$app->params;
+
+$tmpZipFile   = $params->tmpDir . uniqid('zip-');
+$zip = new ZipArchive();
+if ($zip->open($tmpZipFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    die("cannot open <$tmpZipFile>\n");
+}
+
+$motions = $consultation->getVisibleMotionsSorted();
+foreach ($motions as $motion) {
+    $amendments = $motion->getVisibleAmendmentsSorted();
+    foreach ($amendments as $amendment) {
+        $zip->addFromString($amendment->titlePrefix . '.pdf',Exporter::createAmendmentPdf($amendment));
+    }
+}
+$zip->close();
+
+readfile($tmpZipFile);
+unlink($tmpZipFile);

--- a/views/admin/index/index.php
+++ b/views/admin/index/index.php
@@ -59,6 +59,10 @@ foreach ($consultation->motionTypes as $motionType) {
             ': <em>' . $motionp->getPermissionDeniedMotionMsg() . '</em></li>';
     }
 
+    $zipURL  = UrlHelper::createUrl('admin/motion/pdfziplist');
+    echo '<li class="secondary">';
+    echo Html::a(\Yii::t('admin', 'index_pdf_zip_list'), $zipURL, ['class' => 'motionZIP' . $motionType->id]) . '</li>';
+
     $odsUrl = UrlHelper::createUrl(['admin/motion/odslist', 'motionTypeId' => $motionType->id]);
     echo '<li class="secondary">';
     echo Html::a(\Yii::t('admin', 'index_export_ods'), $odsUrl, ['class' => 'motionODS' . $motionType->id]) . '</li>';
@@ -73,6 +77,7 @@ foreach ($consultation->motionTypes as $motionType) {
 
 $amendmentOdsLink  = UrlHelper::createUrl('admin/amendment/odslist');
 $amendmentPDFLink  = UrlHelper::createUrl('admin/amendment/pdflist');
+$amendmentPDFZIPLink  = UrlHelper::createUrl('admin/amendment/pdfziplist');
 $pdfCollectionLink = UrlHelper::createUrl('amendment/pdfcollection');
 echo '<h3>' . \Yii::t('admin', 'index_amendments') . '</h3>
 <ul>
@@ -81,6 +86,9 @@ echo '<h3>' . \Yii::t('admin', 'index_amendments') . '</h3>
     '</li>
     <li class="secondary">' .
     Html::a(\Yii::t('admin', 'index_pdf_list'), $amendmentPDFLink, ['class' => 'amendmentPdfList']) . '
+    </li>
+    <li class="secondary">' .
+    Html::a(\Yii::t('admin', 'index_pdf_zip_list'), $amendmentPDFZIPLink, ['class' => 'amendmentPdfZipList']) . '
     </li>
     <li class="secondary">' .
     Html::a(\Yii::t('admin', 'index_export_ods'), $amendmentOdsLink, ['class' => 'amendmentOds']) .

--- a/views/admin/motion/pdf_zip_list.php
+++ b/views/admin/motion/pdf_zip_list.php
@@ -1,0 +1,32 @@
+<?php
+
+use app\components\latex\Exporter;
+use app\components\UrlHelper;
+
+/**
+ * @var $this yii\web\View
+ * @var array $items
+ */
+
+/** @var \app\controllers\Base $controller */
+$controller   = $this->context;
+$consultation = $controller->consultation;
+
+/** @var \app\models\settings\AntragsgruenApp $params */
+$params = \yii::$app->params;
+
+$tmpZipFile   = $params->tmpDir . uniqid('zip-');
+$zip = new ZipArchive();
+if ($zip->open($tmpZipFile, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+    die("cannot open <$tmpZipFile>\n");
+}
+
+$motions = $consultation->getVisibleMotionsSorted();
+foreach ($motions as $motion) {
+    \Yii::info('memo: ' . memory_get_usage(false) . " / " . memory_get_usage(false));
+    $zip->addFromString($motion->titlePrefix . '.pdf',Exporter::createMotionPdf($motion));
+}
+$zip->close();
+
+readfile($tmpZipFile);
+unlink($tmpZipFile);

--- a/views/amendment/pdf_tex.php
+++ b/views/amendment/pdf_tex.php
@@ -1,32 +1,15 @@
 <?php
 
 use app\components\latex\Exporter;
-use app\components\latex\Layout;
 use app\models\db\Amendment;
-use app\models\settings\AntragsgruenApp;
 use yii\helpers\Html;
 
 /**
  * @var Amendment $amendment
  */
 
-$texTemplate = $amendment->getMyMotion()->motionType->texTemplate;
-
-
-$layout            = new Layout();
-$layout->assetRoot = \yii::$app->basePath . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
-//$layout->templateFile = \yii::$app->basePath . DIRECTORY_SEPARATOR .
-//    'assets' . DIRECTORY_SEPARATOR . 'motion_std.tex';
-$layout->template = $texTemplate->texLayout;
-$layout->author   = $amendment->getInitiatorsStr();
-$layout->title    = $amendment->getTitle();
-
-/** @var AntragsgruenApp $params */
-$params = \yii::$app->params;
 try {
-    $exporter = new Exporter($layout, $params);
-    $content = \app\views\amendment\LayoutHelper::renderTeX($amendment);
-    echo $exporter->createPDF([$content]);
+    echo Exporter::createAmendmentPdf($amendment);
 } catch (\Exception $e) {
     echo 'Ein Fehler trat auf: ' . Html::encode($e);
     die();

--- a/views/motion/pdf_tex.php
+++ b/views/motion/pdf_tex.php
@@ -1,31 +1,15 @@
 <?php
 
 use app\components\latex\Exporter;
-use app\components\latex\Layout;
 use app\models\db\Motion;
-use app\models\settings\AntragsgruenApp;
 use yii\helpers\Html;
 
 /**
  * @var Motion $motion
  */
 
-$texTemplate = $motion->motionType->texTemplate;
-
-$layout            = new Layout();
-$layout->assetRoot = \yii::$app->basePath . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR;
-//$layout->templateFile = \yii::$app->basePath . DIRECTORY_SEPARATOR .
-//    'assets' . DIRECTORY_SEPARATOR . 'motion_std.tex';
-$layout->template = $texTemplate->texLayout;
-$layout->author   = $motion->getInitiatorsStr();
-$layout->title    = $motion->getTitleWithPrefix();
-
 try {
-    /** @var AntragsgruenApp $params */
-    $params   = \yii::$app->params;
-    $exporter = new Exporter($layout, $params);
-    $content  = \app\views\motion\LayoutHelper::renderTeX($motion, $exporter);
-    echo $exporter->createPDF([$content]);
+    echo Exporter::createMotionPdf($motion);
 } catch (\Exception $e) {
     echo 'Ein Fehler trat auf: ' . Html::encode($e);
 }


### PR DESCRIPTION
Ich hab die Erstellung von PDFs aus `views/{motion|amendment}/pdf_tex.php` abstrahiert, um sie auch wo anders verwenden zu können -- bin nicht sicher, ob Exporter dafür der beste Ort war, sonst kannst Du's vielleicht noch wo anders hinschieben.