### PR TITLE
pdf export: include pdf attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.5.0",
-    "fxp/composer-asset-plugin": "~1.1.4",
+    "fxp/composer-asset-plugin": "~1.2.1",
     "yiisoft/yii2": "^2.0.9",
-    "yiisoft/yii2-authclient": "^2.0.6",
+    "yiisoft/yii2-authclient": "^2.1.0",
     "tecnickcom/tcpdf": "^6.2",
-    "slm/mail": "^1.6.0",
+    "slm/mail": "^2.0.0",
     "tijsverkoyen/css-to-inline-styles": "^2.0.0",
     "phpoffice/phpexcel": "^1.8.1",
     "catoth/html2opendocument": "0.5",
-    "simplesamlphp/simplesamlphp": "^1.14.3",
-    "zendframework/zend-servicemanager": "^3.1.0",
+    "simplesamlphp/simplesamlphp": "^1.14.7",
+    "zendframework/zend-servicemanager": "^3.1.1",
     "bower-asset/moment": "dev-master",
     "bower-asset/moment-timezone": "dev-master",
     "bower-asset/Sortable": "dev-master",
@@ -41,10 +41,10 @@
     "yiisoft/yii2-debug": "^2.0.6",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
-    "codeception/codeception": "^2.2.1",
+    "codeception/codeception": "^2.2.4",
     "codeception/specify": "^0.4.3",
-    "codeception/verify": "^0.3.0",
-    "facebook/webdriver": "^1.1.1",
+    "codeception/verify": "^0.3.1",
+    "facebook/webdriver": "^1.1.3",
     "bower-asset/yii2-pjax": "^2.0.3.9999999-dev"
   },
   "extra": {
@@ -63,6 +63,7 @@
     },
     "asset-repositories": [
       {
+        "name": "Sortable",
         "type": "bower-vcs",
         "url": "https://github.com/RubaXa/Sortable"
       }

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
   "minimum-stability": "stable",
   "require": {
     "php": ">=5.5.0",
-    "fxp/composer-asset-plugin": "~1.2.1",
+    "fxp/composer-asset-plugin": "~1.1.4",
     "yiisoft/yii2": "^2.0.9",
-    "yiisoft/yii2-authclient": "^2.1.0",
+    "yiisoft/yii2-authclient": "^2.0.6",
     "tecnickcom/tcpdf": "^6.2",
-    "slm/mail": "^2.0.0",
+    "slm/mail": "^1.6.0",
     "tijsverkoyen/css-to-inline-styles": "^2.0.0",
     "phpoffice/phpexcel": "^1.8.1",
     "catoth/html2opendocument": "0.5",
-    "simplesamlphp/simplesamlphp": "^1.14.7",
-    "zendframework/zend-servicemanager": "^3.1.1",
+    "simplesamlphp/simplesamlphp": "^1.14.3",
+    "zendframework/zend-servicemanager": "^3.1.0",
     "bower-asset/moment": "dev-master",
     "bower-asset/moment-timezone": "dev-master",
     "bower-asset/Sortable": "dev-master",
@@ -33,17 +33,18 @@
     "bower-asset/html5shiv": "^3.7.3-dev",
     "bower-asset/typeahead.js": "^0.11.1-dev",
     "bower-asset/intl": "^1.1.0-dev",
-    "bower-asset/pdfjs-dist": "dev-master"
+    "bower-asset/pdfjs-dist": "dev-master",
+    "setasign/fpdi-tcpdf": "^1.6"
   },
   "require-dev": {
     "yiisoft/yii2-codeception": "^2.0.5",
     "yiisoft/yii2-debug": "^2.0.6",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
-    "codeception/codeception": "^2.2.4",
+    "codeception/codeception": "^2.2.1",
     "codeception/specify": "^0.4.3",
-    "codeception/verify": "^0.3.1",
-    "facebook/webdriver": "^1.1.3",
+    "codeception/verify": "^0.3.0",
+    "facebook/webdriver": "^1.1.1",
     "bower-asset/yii2-pjax": "^2.0.3.9999999-dev"
   },
   "extra": {
@@ -62,7 +63,6 @@
     },
     "asset-repositories": [
       {
-        "name": "Sortable",
         "type": "bower-vcs",
         "url": "https://github.com/RubaXa/Sortable"
       }

--- a/models/VarStream.php
+++ b/models/VarStream.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Source: SETASIGN FPDI FAQ – Using a pdf from a php variable instead of a file
+ * https://www.setasign.com/support/faq/miscellaneous/using-a-pdf-from-a-php-variable-instead-of-a-file/
+ */
+
 namespace app\models;
 
 class VarStream

--- a/models/VarStream.php
+++ b/models/VarStream.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace app\models;
+
+class VarStream
+{
+    private $_pos;
+    private $_stream;
+    private $_cDataIdx;
+
+    static protected $_data = array();
+    static protected $_dataIdx = 0;
+
+    static function createReference(&$var) {
+        $idx = self::$_dataIdx++;
+        self::$_data[$idx] =& $var;
+        return str_replace(__NAMESPACE__.'\\', '', __CLASS__).'://'.$idx;
+    }
+
+    static function unsetReference($path) {
+        $url = parse_url($path);
+        $cDataIdx = $url["host"];
+        if (!isset(self::$_data[$cDataIdx]))
+            return false;
+
+        unset(self::$_data[$cDataIdx]);
+
+        return true;
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path) {
+        $url = parse_url($path);
+        $cDataIdx = $url["host"];
+        if (!isset(self::$_data[$cDataIdx]))
+            return false;
+        $this->_stream = &self::$_data[$cDataIdx];
+        $this->_pos = 0;
+        if (!is_string($this->_stream)) return false;
+        $this->_cDataIdx = $cDataIdx;
+        return true;
+    }
+
+    public function stream_read($count) {
+        $ret = substr($this->_stream, $this->_pos, $count);
+        $this->_pos += strlen($ret);
+        return $ret;
+    }
+
+    public function stream_write($data) {
+        $l=strlen($data);
+        $this->_stream =
+            substr($this->_stream, 0, $this->_pos) .
+            $data .
+            substr($this->_stream, $this->_pos += $l);
+        return $l;
+    }
+
+    public function stream_tell() {
+        return $this->_pos;
+    }
+
+    public function stream_eof() {
+        return $this->_pos >= strlen($this->_stream);
+    }
+
+    public function stream_seek($offset, $whence) {
+        $l=strlen($this->_stream);
+        switch ($whence) {
+            case SEEK_SET: $newPos = $offset; break;
+            case SEEK_CUR: $newPos = $this->_pos + $offset; break;
+            case SEEK_END: $newPos = $l + $offset; break;
+            default: return false;
+        }
+        $ret = ($newPos >= 0 && $newPos <= $l);
+        if ($ret) $this->_pos=$newPos;
+        return $ret;
+    }
+
+    public function url_stat($path, $flags) {
+        $url = parse_url($path);
+        $dataIdx = $url["host"];
+        if (!isset(self::$_data[$dataIdx]))
+            return false;
+
+        $size = strlen(self::$_data[$dataIdx]);
+        return array(
+            7 => $size,
+            'size' => $size
+        );
+    }
+
+    public function stream_stat() {
+        $size = strlen($this->_stream);
+
+        return array(
+            'size' => $size,
+            7 => $size,
+        );
+    }
+}
+
+stream_wrapper_register('VarStream', 'app\models\VarStream') or die('Failed to register protocol VarStream://');

--- a/models/sectionTypes/ISectionType.php
+++ b/models/sectionTypes/ISectionType.php
@@ -187,15 +187,15 @@ abstract class ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    abstract public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf);
+    abstract public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf);
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    abstract public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf);
+    abstract public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf);
 
     /**
      * @param bool $isRight

--- a/models/sectionTypes/Image.php
+++ b/models/sectionTypes/Image.php
@@ -152,9 +152,9 @@ class Image extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         if ($this->isEmpty()) {
             return;
@@ -187,9 +187,9 @@ class Image extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         $this->printMotionToPDF($pdfLayout, $pdf);
     }

--- a/models/sectionTypes/PDF.php
+++ b/models/sectionTypes/PDF.php
@@ -6,6 +6,7 @@ use app\components\latex\Content;
 use app\components\UrlHelper;
 use app\models\db\MotionSection;
 use app\models\exceptions\FormError;
+use app\models\VarStream;
 use app\views\pdfLayouts\IPDFLayout;
 use yii\helpers\Html;
 use CatoTH\HTML2OpenDocument\Text;
@@ -136,7 +137,11 @@ class PDF extends ISectionType
             return;
         }
 
-        $pdf->writeHTML('<p>[PDF] – import not implemented yet</p>'); // @TODO
+        $pdf->writeHTML('<p>[PDF]</p>');
+
+        $data = $this->section->data;
+
+        $pdf->setSourceFile(VarStream::createReference( $data ));
     }
 
     /**

--- a/models/sectionTypes/PDF.php
+++ b/models/sectionTypes/PDF.php
@@ -128,22 +128,22 @@ class PDF extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         if ($this->isEmpty()) {
             return;
         }
 
-        $pdf->writeHTML('<p>[PDF]</p>'); // @TODO
+        $pdf->writeHTML('<p>[PDF] – import not implemented yet</p>'); // @TODO
     }
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         $this->printMotionToPDF($pdfLayout, $pdf);
     }

--- a/models/sectionTypes/PDF.php
+++ b/models/sectionTypes/PDF.php
@@ -139,9 +139,16 @@ class PDF extends ISectionType
 
         $pdf->writeHTML('<p>[PDF]</p>');
 
-        $data = $this->section->data;
+        $data = base64_decode($this->section->data);
 
-        $pdf->setSourceFile(VarStream::createReference( $data ));
+        $pageCount = $pdf->setSourceFile(VarStream::createReference( $data ));
+
+        for ($pageNo = 1; $pageNo <= $pageCount; $pageNo++) {
+            $page = $pdf->ImportPage($pageNo);
+            $dim = $pdf->getTemplatesize($page);
+            $pdf->AddPage($dim['w'] > $dim['h'] ? 'L' : 'P', array($dim['w'], $dim['h']));
+            $pdf->useTemplate($page);
+        }
     }
 
     /**

--- a/models/sectionTypes/PDF.php
+++ b/models/sectionTypes/PDF.php
@@ -137,7 +137,7 @@ class PDF extends ISectionType
             return;
         }
 
-        $pdf->writeHTML('<p>[PDF]</p>');
+        $pdf->writeHTML('<h3>'.$this->section->getSettings()->title.' [PDF]</h3>');
 
         $data = base64_decode($this->section->data);
 

--- a/models/sectionTypes/TabularData.php
+++ b/models/sectionTypes/TabularData.php
@@ -127,9 +127,9 @@ class TabularData extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         if ($this->isEmpty()) {
             return;
@@ -162,9 +162,9 @@ class TabularData extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         $this->printAmendmentToPDF($pdfLayout, $pdf);
     }

--- a/models/sectionTypes/TextHTML.php
+++ b/models/sectionTypes/TextHTML.php
@@ -82,9 +82,9 @@ class TextHTML extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         if ($this->isEmpty()) {
             return;
@@ -110,9 +110,9 @@ class TextHTML extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         $this->printMotionToPDF($pdfLayout, $pdf);
     }

--- a/models/sectionTypes/TextSimple.php
+++ b/models/sectionTypes/TextSimple.php
@@ -234,10 +234,10 @@ class TextSimple extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      * @throws \app\models\exceptions\Internal
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         if ($this->isEmpty()) {
             return;
@@ -309,9 +309,9 @@ class TextSimple extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         /** @var AmendmentSection $section */
         $section    = $this->section;

--- a/models/sectionTypes/Title.php
+++ b/models/sectionTypes/Title.php
@@ -118,19 +118,19 @@ class Title extends ISectionType
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function printMotionToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printMotionToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         // TODO: Implement printMotionToPDF() method.
     }
 
     /**
      * @param IPDFLayout $pdfLayout
-     * @param \TCPDF $pdf
+     * @param \FPDI $pdf
      */
-    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \TCPDF $pdf)
+    public function printAmendmentToPDF(IPDFLayout $pdfLayout, \FPDI $pdf)
     {
         /** @var AmendmentSection $section */
         $section = $this->section;

--- a/views/motion/pdf_tcpdf.php
+++ b/views/motion/pdf_tcpdf.php
@@ -30,6 +30,7 @@ $pdfLayout->printMotionHeader($motion);
 
 
 foreach ($motion->getSortedSections(true) as $section) {
+	// echo '<pre>'.print_r($section->getSectionType(),true).'</pre><hr/>';
     $section->getSectionType()->printMotionToPDF($pdfLayout, $pdf);
 }
 

--- a/views/motion/pdf_tcpdf.php
+++ b/views/motion/pdf_tcpdf.php
@@ -30,7 +30,6 @@ $pdfLayout->printMotionHeader($motion);
 
 
 foreach ($motion->getSortedSections(true) as $section) {
-	// echo '<pre>'.print_r($section->getSectionType(),true).'</pre><hr/>';
     $section->getSectionType()->printMotionToPDF($pdfLayout, $pdf);
 }
 

--- a/views/pdfLayouts/BDK.php
+++ b/views/pdfLayouts/BDK.php
@@ -13,7 +13,7 @@ class BDK extends IPDFLayout
     protected $pdf;
 
     /**
-     * @return \TCPDF
+     * @return \FPDI
      */
     public function createPDFClass()
     {

--- a/views/pdfLayouts/BDKPDF.php
+++ b/views/pdfLayouts/BDKPDF.php
@@ -5,7 +5,7 @@ namespace app\views\pdfLayouts;
 use Yii;
 use yii\helpers\Html;
 
-class BDKPDF extends \TCPDF
+class BDKPDF extends \FPDI
 {
     private $headerTitle;
     private $headerPrefix;

--- a/views/pdfLayouts/ByLDKPDF.php
+++ b/views/pdfLayouts/ByLDKPDF.php
@@ -4,7 +4,7 @@ namespace app\views\pdfLayouts;
 
 use Yii;
 
-class ByLDKPDF extends \TCPDF
+class ByLDKPDF extends \FPDI
 {
     /** @var IPDFLayout */
     private $layout;

--- a/views/pdfLayouts/DBJRPDF.php
+++ b/views/pdfLayouts/DBJRPDF.php
@@ -4,7 +4,7 @@ namespace app\views\pdfLayouts;
 
 use Yii;
 
-class DBJRPDF extends \TCPDF
+class DBJRPDF extends \FPDI
 {
     /** @var IPDFLayout */
     private $layout;


### PR DESCRIPTION
Since TCPDF doesn't support the inclusion of other PDF-Files as template and other inclusion times innately, FPDI has been added via composer. FPDI extends TCPDF so everywhere, TCPDF was used, now FPDI has to be used.

PDF attachments are included within the pdf-export now.