### PR TITLE
BugFix

### DIFF
--- a/models/sectionTypes/PDF.php
+++ b/models/sectionTypes/PDF.php
@@ -137,7 +137,14 @@ class PDF extends ISectionType
             return;
         }
 
-        $pdf->writeHTML('<h3>'.$this->section->getSettings()->title.' [PDF]</h3>');
+        $abs = 5;
+        $pdf->setY($pdf->getY() + $abs);
+
+        $title = $this->section->getSettings()->title;
+        if (str_replace('pdf','',strtolower($title))==strtolower($title)) {
+            $title .= ' [PDF]';
+        }
+        $pdf->writeHTML('<h3>'.$title.'</h3>');
 
         $data = base64_decode($this->section->data);
 
@@ -146,7 +153,7 @@ class PDF extends ISectionType
         for ($pageNo = 1; $pageNo <= $pageCount; $pageNo++) {
             $page = $pdf->ImportPage($pageNo);
             $dim = $pdf->getTemplatesize($page);
-            $pdf->AddPage($dim['w'] > $dim['h'] ? 'L' : 'P', array($dim['w'], $dim['h']));
+            $pdf->AddPage($dim['w'] > $dim['h'] ? 'L' : 'P', array($dim['w'], $dim['h']), false, false, false);
             $pdf->useTemplate($page);
         }
     }

--- a/views/pdfLayouts/BDKPDF.php
+++ b/views/pdfLayouts/BDKPDF.php
@@ -18,6 +18,14 @@ class BDKPDF extends \FPDI
     }
 
     /**
+     * rewrite AddPage() for correct functionalities with PDF Concatenation
+     */
+    public function AddPage ($orientation = PDF_PAGE_ORIENTATION, $format = PDF_PAGE_FORMAT, $keepmargins = false, $tocpage = false, $footer = true) {
+        parent::AddPage($orientation, $format, $keepmargins, $tocpage);
+        $this->setPrintFooter($footer);
+    }
+
+    /**
      * @param string $prefix
      * @param string $title
      */

--- a/views/pdfLayouts/ByLDKPDF.php
+++ b/views/pdfLayouts/ByLDKPDF.php
@@ -18,6 +18,14 @@ class ByLDKPDF extends \FPDI
         parent::__construct(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
     }
 
+    /**
+     * rewrite AddPage() for correct functionalities with PDF Concatenation
+     */
+    public function AddPage ($orientation = PDF_PAGE_ORIENTATION, $format = PDF_PAGE_FORMAT, $keepmargins = false, $tocpage = false, $footer = true) {
+        parent::AddPage($orientation, $format, $keepmargins, $tocpage);
+        $this->setPrintFooter($footer);
+    }
+
     // @codingStandardsIgnoreStart
     /**
      */

--- a/views/pdfLayouts/DBJRPDF.php
+++ b/views/pdfLayouts/DBJRPDF.php
@@ -18,6 +18,14 @@ class DBJRPDF extends \FPDI
         parent::__construct(PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
     }
 
+    /**
+     * rewrite AddPage() for correct functionalities with PDF Concatenation
+     */
+    public function AddPage ($orientation = PDF_PAGE_ORIENTATION, $format = PDF_PAGE_FORMAT, $keepmargins = false, $tocpage = false, $footer = true) {
+        parent::AddPage($orientation, $format, $keepmargins, $tocpage);
+        $this->setPrintFooter($footer);
+    }
+
     // @codingStandardsIgnoreStart
     /**
      */


### PR DESCRIPTION
concatenating pdf files with other than the original Dimensions resulted the remaining PDF staying with these dimensions
PDF-footer could overprint footer of concatenated PDF – removed Template-Footer from concatenated PDF-pages

This BugFix is also included within https://github.com/CatoTH/antragsgruen/pull/202.