### PR TITLE
Upgrade 3.8 to 4.0/4.2.1 fixes

### DIFF
--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -28,6 +28,15 @@ If you don't have shell access to the server, installing major new versions (e.g
 
 Here is a list of SQL statements necessary to upgrade, starting with the upgrade from 3.6 to 3.7:
 
+#### Upgrading from 3.8 to 4.0
+
+```sql
+ALTER TABLE `consultationText` ADD `menuPosition` INT DEFAULT NULL AFTER `textId`;
+```
+
+Disable the `addColumn` line in [m180609_095225_consultation_text_in_menu](../migrations/m180609_095225_consultation_text_in_menu.php#L15) or mark the migration as done with `./yii migrate/mark m180609_095225_consultation_text_in_menu`.
+
+
 #### Upgrading from 3.7 to 3.8
 
 ```sql

--- a/models/settings/Site.php
+++ b/models/settings/Site.php
@@ -10,13 +10,19 @@ class Site implements \JsonSerializable
     public $siteLayout = 'layout-classic';
 
     /** @var bool */
-    public $showAntragsgruenAd = true;
+    public $showAntragsgruenAd  = true;
+    public $forceLogin          = false;
+    public $managedUserAccounts = false;
 
     /** @var int[] */
     public $loginMethods = [0, 1, 3];
 
     /** @var array */
     public $stylesheetSettings = [];
+
+    /** @var null|string */
+    public $emailReplyTo  = null;
+    public $emailFromName = null;
 
     const LOGIN_STD        = 0;
     const LOGIN_WURZELWERK = 1;


### PR DESCRIPTION
Hi,

this PR contains two small fixes to upgrade from 3.8 to 4.2.1:

- Add missing properties to site settings that are used in database migrations [m180619_080947_email_settings_to_consultations](https://github.com/CatoTH/antragsgruen/blob/master/migrations/m180619_080947_email_settings_to_consultations.php#L21-L22) and [m180621_113721_login_settings_to_consultation](https://github.com/CatoTH/antragsgruen/blob/master/migrations/m180621_113721_login_settings_to_consultation.php#L21-L22)
- Add a hint to upgrade documentation how to add missing property `menuPosition` used in consultation text model (this fixes #328)