### PR TITLE
set default time zone

### DIFF
--- a/config/common.php
+++ b/config/common.php
@@ -10,7 +10,9 @@ use app\models\settings\AntragsgruenApp;
 require_once(__DIR__ . DIRECTORY_SEPARATOR . 'defines.php');
 
 if (ini_get('date.timezone') == '') {
-    date_default_timezone_set('Europe/Berlin');
+    $timezone = 'Europe/Berlin';
+    date_default_timezone_set($timezone);
+    ini_set('date.timezone', $timezone);
 }
 ini_set('tidy.clean_output', false);
 ini_set('default_charset', 'UTF-8');


### PR DESCRIPTION
Strangely, `date_default_timezone_set` doesn't set the default timezone properly in our setting (Ubuntu 16.04.6 LTS (GNU/Linux 4.4.0-142-generic x86_64), PHP 7.0.33-0ubuntu0.16.04.4 (cli) (NTS)). If you call it with `Europe/Berlin` and then immeditely call `date_default_timezone_get`, it still returns `UTC`. Instead, `ini_set('date.timezone', $timezone)` works. I added it, instead of replacing the call to `date_default_timezone_set`, since I don't know whether this works in other settings.