### PR TITLE
Doc: remove explicit vue version

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Developing
 
 - PHP version support: Antragsgrün supports PHP versions for one year after its end of life (that is, if PHP 7.2 is supported until end 2020, the first major version of Antragsgrün after end 2021 will drop support for PHP 7.2).
 - PHP Framework: [Yii2](https://www.yiiframework.com/) is used. While it would not being the framework of choice for a fresh start anymore, it works sufficiently well since its introduction in 2015 and is still supported, so there is no plan to migrate to Symfony of Laravel as of yet.
-- JavaScript: Good old [JQuery](https://jquery.com/) is used for simple interactions, though written in TypeScript and loaded via [RequireJS](https://requirejs.org/). For more complex widgets like voting, speaking lists or amendment merging, [Vue.JS 2](https://vuejs.org/) is used. There is no plan to redesign Antragsgrün into being a Single-Page-App.
+- JavaScript: Good old [JQuery](https://jquery.com/) is used for simple interactions, though written in TypeScript and loaded via [RequireJS](https://requirejs.org/). For more complex widgets like voting, speaking lists or amendment merging, [Vue.JS](https://vuejs.org/) is used. There is no plan to redesign Antragsgrün into being a Single-Page-App.
 - REST API: The API is documented below. There will be more development regarding the REST API, including authorized endpoints using JWT based authentication.
 
 ### Compiling from source


### PR DESCRIPTION
Current version can be found in the package.json