### PR TITLE
Add supported nodejs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
         "watch": "gulp watch",
         "build": "gulp"
     },
+    "engines": {
+        "node": ">=16"
+    },
     "devDependencies": {
         "@types/bootbox": "^5.2.3",
         "@types/bootstrap": "^3.4.0",


### PR DESCRIPTION
Gives developers a hint which nodejs version works.

Tested with current nodejs 16.

## Reference

* https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines
* #624
