### PR TITLE
Fixing php syntax in lang/de-spdth

### DIFF
--- a/messages/de-spdth/wizard.php
+++ b/messages/de-spdth/wizard.php
@@ -15,3 +15,4 @@ return [
                                 <br><br>
                                 Bitte beachte aber, dass dies nur eine Test-Seite ist und <strong>nach drei Tagen wieder gelöscht</strong> wird.<br><br>
                                 <em>Diesen Text kannst du übrigens bearbeiten, indem du rechts oben auf "Bearbeiten" klickst.</em>',
+];


### PR DESCRIPTION
there was an c&p error in your manual copy from accidental commiting to master or my initial PR it seems. Fixed it.