### PR TITLE
Allow reverse proxies

### DIFF
--- a/components/UrlHelper.php
+++ b/components/UrlHelper.php
@@ -278,7 +278,7 @@ class UrlHelper
         if (!$urlParts) {
             throw new FormError('Unable to parse the url');
         }
-        $scheme   = $urlParts['scheme'] ?? ($_SERVER['REQUEST_SCHEME'] ?? 'http');
+        $scheme   = $urlParts['scheme'] ?? ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? ($_SERVER['REQUEST_SCHEME'] ?? 'http'));
         $host     = $urlParts['host'] ?? $_SERVER['HTTP_HOST'];
         $fullhost = $scheme . '://' . $host . '/';
         if ($params->domainPlain === $fullhost) {


### PR DESCRIPTION
This change fixes a bug when the app is running on "http" and is deployed behind a reverse proxy running on "https" 

It fails in the url comparison since the https != http which is used in $_SERVER['REQUEST_SCHEME'].

$_SERVER['HTTP_X_FORWARDED_PROTO']  takes precedent over  $_SERVER['REQUEST_SCHEME']