### PR TITLE
Grouped dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       interval: "monthly"
       timezone: "Europe/Berlin"
       time: "05:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
News:
https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/

Result:
Just one PR instead of one PR per updated dependency.