### PR TITLE
fix(php): visibility required

### DIFF
--- a/models/db/Consultation.php
+++ b/models/db/Consultation.php
@@ -82,8 +82,8 @@ class Consultation extends ActiveRecord
         return $this->hasOne(Site::class, ['id' => 'siteId']);
     }
 
-    const PRELOAD_ONLY_AMENDMENTS = 'amendments';
-    const PRELOAD_ALL = 'all';
+    public const PRELOAD_ONLY_AMENDMENTS = 'amendments';
+    public const PRELOAD_ALL = 'all';
     private ?string $preloadedAllMotionData = null;
     private ?array $preloadedAmendmentIds  = null;
 

--- a/models/sectionTypes/ISectionType.php
+++ b/models/sectionTypes/ISectionType.php
@@ -14,23 +14,23 @@ use yii\helpers\Html;
 abstract class ISectionType
 {
     // Synchronize with MotionTypeEdit.ts
-    const TYPE_TITLE           = 0;
-    const TYPE_TEXT_SIMPLE     = 1;
-    const TYPE_TEXT_HTML       = 2;
-    const TYPE_IMAGE           = 3;
-    const TYPE_TABULAR         = 4;
-    const TYPE_PDF_ATTACHMENT  = 5;
-    const TYPE_PDF_ALTERNATIVE = 6;
-    const TYPE_VIDEO_EMBED     = 7;
+    public const TYPE_TITLE           = 0;
+    public const TYPE_TEXT_SIMPLE     = 1;
+    public const TYPE_TEXT_HTML       = 2;
+    public const TYPE_IMAGE           = 3;
+    public const TYPE_TABULAR         = 4;
+    public const TYPE_PDF_ATTACHMENT  = 5;
+    public const TYPE_PDF_ALTERNATIVE = 6;
+    public const TYPE_VIDEO_EMBED     = 7;
 
-    const TYPE_API_TITLE = 'Title';
-    const TYPE_API_TEXT_SIMPLE = 'TextSimple';
-    const TYPE_API_TEXT_HTML = 'TextHTML';
-    const TYPE_API_IMAGE = 'Image';
-    const TYPE_API_TABULAR = 'TabularData';
-    const TYPE_API_PDF_ATTACHMENT = 'PDFAttachment';
-    const TYPE_API_PDF_ALTERNATIVE = 'PDFAlternative';
-    const TYPE_API_VIDEO_EMBED = 'VideoEmbed';
+    public const TYPE_API_TITLE = 'Title';
+    public const TYPE_API_TEXT_SIMPLE = 'TextSimple';
+    public const TYPE_API_TEXT_HTML = 'TextHTML';
+    public const TYPE_API_IMAGE = 'Image';
+    public const TYPE_API_TABULAR = 'TabularData';
+    public const TYPE_API_PDF_ATTACHMENT = 'PDFAttachment';
+    public const TYPE_API_PDF_ALTERNATIVE = 'PDFAlternative';
+    public const TYPE_API_VIDEO_EMBED = 'VideoEmbed';
 
     protected IMotionSection $section;
     protected bool $absolutizeLinks = false;

--- a/models/settings/InitiatorForm.php
+++ b/models/settings/InitiatorForm.php
@@ -6,9 +6,9 @@ class InitiatorForm implements \JsonSerializable
 {
     use JsonConfigTrait;
 
-    const CONTACT_NONE = 0;
-    const CONTACT_OPTIONAL = 1;
-    const CONTACT_REQUIRED = 2;
+    public const CONTACT_NONE = 0;
+    public const CONTACT_OPTIONAL = 1;
+    public const CONTACT_REQUIRED = 2;
 
     public int $type = 0;
 

--- a/models/settings/Stylesheet.php
+++ b/models/settings/Stylesheet.php
@@ -6,15 +6,15 @@ class Stylesheet implements \JsonSerializable
 {
     use JsonConfigTrait;
 
-    const TYPE_COLOR = 'color';
-    const TYPE_CHECKBOX = 'checkbox';
-    const TYPE_PIXEL = 'pixel';
-    const TYPE_NUMBER = 'number';
-    const TYPE_FONT = 'font';
-    const TYPE_IMAGE = 'image';
+    public const TYPE_COLOR = 'color';
+    public const TYPE_CHECKBOX = 'checkbox';
+    public const TYPE_PIXEL = 'pixel';
+    public const TYPE_NUMBER = 'number';
+    public const TYPE_FONT = 'font';
+    public const TYPE_IMAGE = 'image';
 
-    const DEFAULTS_LAYOUT_CLASSIC = 'layout-classic';
-    const DEFAULTS_LAYOUT_DBJR = 'layout-dbjr';
+    public const DEFAULTS_LAYOUT_CLASSIC = 'layout-classic';
+    public const DEFAULTS_LAYOUT_DBJR = 'layout-dbjr';
 
     public string $bodyFont;
     public int $bodyFontSize;

--- a/models/settings/VotingData.php
+++ b/models/settings/VotingData.php
@@ -10,7 +10,7 @@ use app\models\db\{IVotingItem, Vote, VotingBlock};
 
 class VotingData implements \JsonSerializable
 {
-    const ORGANIZATION_DEFAULT = '0';
+    public const ORGANIZATION_DEFAULT = '0';
 
     use JsonConfigTrait;
 

--- a/models/supportTypes/SupportBase.php
+++ b/models/supportTypes/SupportBase.php
@@ -16,14 +16,14 @@ use yii\web\View;
 abstract class SupportBase
 {
     // Also defined in Typescript
-    const ONLY_INITIATOR        = 0;
-    const GIVEN_BY_INITIATOR    = 1;
-    const COLLECTING_SUPPORTERS = 2;
-    const NO_INITIATOR          = 3;
+    public const ONLY_INITIATOR        = 0;
+    public const GIVEN_BY_INITIATOR    = 1;
+    public const COLLECTING_SUPPORTERS = 2;
+    public const NO_INITIATOR          = 3;
 
-    const LIKEDISLIKE_LIKE    = 1;
-    const LIKEDISLIKE_DISLIKE = 2;
-    const LIKEDISLIKE_SUPPORT = 4;
+    public const LIKEDISLIKE_LIKE    = 1;
+    public const LIKEDISLIKE_DISLIKE = 2;
+    public const LIKEDISLIKE_SUPPORT = 4;
 
     protected bool $adminMode = false;
     protected InitiatorForm $settingsObject;

--- a/models/votings/VotingItemGroup.php
+++ b/models/votings/VotingItemGroup.php
@@ -9,9 +9,9 @@ use app\models\exceptions\FormError;
 
 class VotingItemGroup
 {
-    const ADHOC_PREFIX = 'adhoc-';
-    const ADHOC_PREFIX_MOTION = 'motion-';
-    const ADHOC_PREFIX_AMENDMENT = 'amendment-';
+    public const ADHOC_PREFIX = 'adhoc-';
+    public const ADHOC_PREFIX_MOTION = 'motion-';
+    public const ADHOC_PREFIX_AMENDMENT = 'amendment-';
 
     public string $groupId;
     public ?string $groupName;

--- a/plugins/drupal_civicrm/DrupalPasswordHashing.php
+++ b/plugins/drupal_civicrm/DrupalPasswordHashing.php
@@ -10,9 +10,9 @@ namespace app\plugins\drupal_civicrm;
  */
 class DrupalPasswordHashing
 {
-    const DRUPAL_MIN_HASH_COUNT = 7;
-    const DRUPAL_MAX_HASH_COUNT = 30;
-    const DRUPAL_HASH_LENGTH = 55;
+    public const DRUPAL_MIN_HASH_COUNT = 7;
+    public const DRUPAL_MAX_HASH_COUNT = 30;
+    public const DRUPAL_HASH_LENGTH = 55;
 
     private static function _password_base64_encode(string $input, int $count): string
     {

--- a/plugins/egp/LayoutHooks.php
+++ b/plugins/egp/LayoutHooks.php
@@ -14,7 +14,7 @@ use yii\helpers\Html;
 
 class LayoutHooks extends Hooks
 {
-    const CANDIDATURE_TYPES = [9];
+    public const CANDIDATURE_TYPES = [9];
 
     public function beginPage(string $before): string
     {

--- a/tests/Support/Helper/ConfigurationChanger.php
+++ b/tests/Support/Helper/ConfigurationChanger.php
@@ -10,7 +10,7 @@ use Yii;
 
 class ConfigurationChanger extends Module
 {
-    const DEFAULT_CONFIGURATION = [
+    public const DEFAULT_CONFIGURATION = [
         'confirmEmailAddresses' => true,
         'xelatexPath'           => null,
         'xdvipdfmx'             => null,


### PR DESCRIPTION
Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.

Source: https://cs.symfony.com/doc/rules/class_notation/visibility_required.html