### PR TITLE
fix: remove outdated browser polyfill for intl

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,6 @@ const main_js_files = [
     "node_modules/bootbox/bootbox.all.js",
     "web/js/scrollintoview.js",
     "web/js/jquery.isonscreen.js",
-    "node_modules/intl/dist/Intl.min.js",
 ];
 
 async function taskCopyFiles() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "bootstrap-toggle": "^2.2.2",
                 "clipboard": "^2.0.8",
                 "corejs-typeahead": "^1.3.1",
-                "intl": "^1.2.5",
                 "isotope-layout": "^3.0.6",
                 "jquery": "^3.6.0",
                 "moment": "^2.29.1",
@@ -4123,11 +4122,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/intl": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
-            "integrity": "sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw=="
         },
         "node_modules/invert-kv": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "bootstrap-toggle": "^2.2.2",
         "clipboard": "^2.0.8",
         "corejs-typeahead": "^1.3.1",
-        "intl": "^1.2.5",
         "isotope-layout": "^3.0.6",
         "jquery": "^3.6.0",
         "moment": "^2.29.1",


### PR DESCRIPTION
Library not maintained anymore:
https://github.com/andyearnshaw/Intl.js/issues/341 

Modern browsers do support intl out of the box.