### PR TITLE
Remove unused npm `cloneable-readable`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
                 "@typescript-eslint/parser": "^6.21.0",
                 "autoprefixer": "^10.4.1",
-                "cloneable-readable": "^2.1.0",
                 "eslint": "^8.56.0",
                 "eslint-plugin-promise": "^6.1.1",
                 "eslint-plugin-unicorn": "^51.0.1",
@@ -1911,16 +1910,6 @@
             "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
             "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
             "dev": true
-        },
-        "node_modules/cloneable-readable": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-2.1.0.tgz",
-            "integrity": "sha512-GP0FuTTREdvgNQwJzvLVcPCrHwsryC/KSrDlrWM3nyXpvskmAwT55G8LwQpjS5VHrZfaeqABwSOdYBuuqUzRfQ==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^3.3.0"
-            }
         },
         "node_modules/code-point-at": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "autoprefixer": "^10.4.1",
-        "cloneable-readable": "^2.1.0",
         "eslint": "^8.56.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-unicorn": "^51.0.1",


### PR DESCRIPTION
Seems not directly used. May be an old (optional peer) dependency.