### PR TITLE
Fix that small sidebar would not say resolutions for PDFs

### DIFF
--- a/views/consultation/sidebar.php
+++ b/views/consultation/sidebar.php
@@ -250,7 +250,7 @@ if ($hasPDF) {
             $name    = '<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>' . Yii::t('con', 'pdf_resolutions');
             $html    .= '<li>' . HtmlTools::createExternalLink($name, $pdfLink, ['class' => 'resolutionPdfCompilation']) . '</li>';
 
-            $link                     = Html::a(Yii::t('con', 'pdf_motions'), $pdfLink, $opts);
+            $link                     = Html::a(Yii::t('con', 'pdf_resolutions'), $pdfLink, $opts);
             $menusSmall[] = '<li>' . $link . '</li>';
         }
 


### PR DESCRIPTION
Currently the small (mobile) sidebar will say the `pdf_motions` text twice which is quite confusing as the first is the resolutions:

![image](https://github.com/user-attachments/assets/d0cc8b33-e9bd-4080-964b-98ad698482dc)

But the non-small sidebar talks about the resolutions:

![image](https://github.com/user-attachments/assets/ca98e8fd-444f-4800-917b-17019fd946fa)

The fix just re-uses the `pdf_resolutions` key which should make it look something like this:

![image](https://github.com/user-attachments/assets/156c3407-199d-4558-94b8-03af6b4efc1a)
