### PR TITLE
Prevent urlencode throw an exception

### DIFF
--- a/components/mail/SMTP.php
+++ b/components/mail/SMTP.php
@@ -12,8 +12,8 @@ class SMTP extends Base
 {
     private string $host;
     private int $port = 25;
-    private ?string $username = null;
-    private ?string $password = null;
+    private ?string $username = "";
+    private ?string $password = "";
     /** @phpstan-ignore-next-line  */
     private ?string $encryption = null;
 

--- a/components/mail/SMTP.php
+++ b/components/mail/SMTP.php
@@ -12,8 +12,8 @@ class SMTP extends Base
 {
     private string $host;
     private int $port = 25;
-    private ?string $username = "";
-    private ?string $password = "";
+    private ?string $username = null;
+    private ?string $password = null;
     /** @phpstan-ignore-next-line  */
     private ?string $encryption = null;
 
@@ -71,8 +71,12 @@ class SMTP extends Base
 
         return new \Swift_Mailer($transport);
         */
-        $dsn = 'smtp://' . urlencode($this->username) . ':' . urlencode($this->password) . '@' .
-            urlencode($this->host) . ':' . $this->port;
+        if ($this->username && $this->password) {
+            $dsn = 'smtp://' . urlencode($this->username) . ':' . urlencode($this->password) . '@' .
+                urlencode($this->host) . ':' . $this->port;
+        } else {
+            $dsn = 'smtp://' . urlencode($this->host) . ':' . $this->port;
+        }
 
         return Transport::fromDsn($dsn);
     }


### PR DESCRIPTION
`declare(strict_types=1);`
Introduced here
https://github.com/CatoTH/antragsgruen/commit/349522e7996c46ccb9007ac00c191b29aee8df7b#diff-5bd33395e5715c82071cef80cbfbb57ff327fd27e99c62c6d39da556d83c074bR3

This change makes no authentication throw, an exception

We use IP based auth and don't; need username and password. 

`urlencode` expects a string. Before strict_types it was ok to pass null now it throws.