### PR TITLE
feat: add OpenTelemetry as a Yii2 plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,13 @@
     "yiisoft/yii2-redis": "Allows using redis for caching",
     "simplesamlphp/simplesamlphp": "Allowed Single Sign On Authentication using SAML",
     "league/oauth2-client": "Allows Single Sign On Authentication using OIDC",
-    "predis/predis": "If simplesaml should store its data to redis"
+    "predis/predis": "If simplesaml should store its data to redis",
+    "open-telemetry/sdk": "OpenTelemetry SDK for the opentelemetry plugin",
+    "open-telemetry/exporter-otlp": "OTLP exporter for the opentelemetry plugin",
+    "open-telemetry/opentelemetry-auto-pdo": "Auto-instruments database queries",
+    "open-telemetry/opentelemetry-auto-curl": "Auto-instruments curl HTTP calls",
+    "open-telemetry/opentelemetry-auto-guzzle": "Auto-instruments Guzzle HTTP calls",
+    "php-http/guzzle7-adapter": "HTTP transport for OTLP exporter"
   },
   "config": {
     "platform": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,10 @@ parameters:
       -
           message: '#PHPDoc tag @var for variable \$app contains generic class yii\\web\\Application but does not specify its types#'
           path: plugins/generic_sso/*
+      # OpenTelemetry plugin uses optional dependencies (open-telemetry/sdk)
+      -
+          message: '#(has unknown class|on an unknown class|Instantiated class|not found) .*OpenTelemetry#'
+          path: plugins/opentelemetry/*
     scanDirectories:
       - vendor
     scanFiles:

--- a/plugins/opentelemetry/Module.php
+++ b/plugins/opentelemetry/Module.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace app\plugins\opentelemetry;
+
+use app\plugins\ModuleBase;
+use yii\base\BootstrapInterface;
+
+class Module extends ModuleBase implements BootstrapInterface
+{
+    public function bootstrap($app): void
+    {
+        if (getenv('OTEL_PHP_AUTOLOAD_ENABLED') !== 'true') {
+            return;
+        }
+        $app->log->targets['otel'] = \Yii::createObject([
+            'class' => OpenTelemetryLogTarget::class,
+            'levels' => ['error', 'warning', 'info'],
+        ]);
+    }
+}

--- a/plugins/opentelemetry/OpenTelemetryLogTarget.php
+++ b/plugins/opentelemetry/OpenTelemetryLogTarget.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace app\plugins\opentelemetry;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\Severity;
+use yii\log\Logger;
+use yii\log\Target;
+
+class OpenTelemetryLogTarget extends Target
+{
+    private const LEVEL_MAP = [
+        Logger::LEVEL_ERROR => Severity::ERROR,
+        Logger::LEVEL_WARNING => Severity::WARN,
+        Logger::LEVEL_INFO => Severity::INFO,
+        Logger::LEVEL_TRACE => Severity::DEBUG,
+        Logger::LEVEL_PROFILE => Severity::DEBUG,
+        Logger::LEVEL_PROFILE_BEGIN => Severity::DEBUG,
+        Logger::LEVEL_PROFILE_END => Severity::DEBUG,
+    ];
+
+    public function export(): void
+    {
+        $logger = Globals::loggerProvider()->getLogger('yii2');
+
+        foreach ($this->messages as $message) {
+            [$text, $level, $category, $timestamp] = $message;
+
+            if (!is_string($text)) {
+                $text = var_export($text, true);
+            }
+
+            $severity = self::LEVEL_MAP[$level] ?? Severity::UNSPECIFIED;
+
+            $logger->emit(
+                (new \OpenTelemetry\API\Logs\LogRecord($text))
+                    ->setSeverityNumber($severity->value)
+                    ->setSeverityText($severity->name)
+                    ->setTimestamp((int)($timestamp * 1_000_000_000))
+                    ->setAttribute('yii.category', $category)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds an optional OpenTelemetry plugin that bridges Yii2 logs to OTel LogRecords with automatic trace correlation.

## Changes

- `plugins/opentelemetry/Module.php` — Yii2 module implementing `BootstrapInterface`. Checks `OTEL_PHP_AUTOLOAD_ENABLED=true` on bootstrap and registers the log target. No-op otherwise, zero overhead when disabled.
- `plugins/opentelemetry/OpenTelemetryLogTarget.php` — Maps Yii2 log levels to OTel Severity and emits LogRecords via `Globals::loggerProvider()`. Logs are automatically linked to the active trace/span.
- `composer.json` — OTel packages added to `suggest`, not `require`.
- `phpstan.neon` — Ignore unknown class errors for optional OTel dependencies (same pattern as `generic_sso`).

## Related

Container build layer that installs the OTel runtime: [motion-tools-container#11](https://github.com/antoinetielbeke/motion-tools-container/pull/11)

## Approach

Follows the same pattern as SAML (`simplesamlphp` in suggest, `generic_sso` as plugin): the codebase ships the integration code, but doesn't force the ~15 transitive OTel dependencies on everyone. Deployers who want observability install the packages in their container build and activate via environment variables — everyone else is unaffected.

This keeps a clean separation: the plugin provides the *capability*, the container build provides the *runtime*, and env vars make the *decision*.

## Usage

1. Install the suggested packages (`open-telemetry/sdk`, `open-telemetry/exporter-otlp`, etc.)
2. Add `"opentelemetry"` to `plugins` in `config.json`
3. Set `OTEL_PHP_AUTOLOAD_ENABLED=true` and the standard OTel env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, etc.)

Without step 3, the plugin loads but does nothing.