### PR TITLE
Fix generic_sso translations not overridable via admin UI

### DIFF
--- a/plugins/generic_sso/Module.php
+++ b/plugins/generic_sso/Module.php
@@ -14,20 +14,6 @@ class Module extends ModuleBase
 
     private static ?LoginProviderInterface $loginProvider = null;
 
-    public function init(): void
-    {
-        parent::init();
-
-        // Register translation category
-        \Yii::$app->i18n->translations['generic_sso'] = [
-            'class' => 'yii\i18n\PhpMessageSource',
-            'basePath' => '@app/plugins/generic_sso/messages',
-            'fileMap' => [
-                'generic_sso' => 'generic_sso.php',
-            ],
-        ];
-    }
-
     public static function getDedicatedLoginProvider(): ?LoginProviderInterface
     {
         if (self::$loginProvider === null) {


### PR DESCRIPTION
## Summary

- The `generic_sso` plugin registered its own `PhpMessageSource`, which overrode the app's custom `MessageSource` wildcard handler
- This prevented `ConsultationText` database overrides from being applied to SSO login text
- Admins could not customize provider name, button text, or description through the Translation/Wording admin UI
- Removing the explicit registration fixes this, since `MessageSource` already resolves plugin message files via `getMessageFilePath()` and exposes plugin categories via `getTranslatableCategories()`

## Test plan

- [ ] Go to Admin > Translation/Wording > click the `generic_sso` category
- [ ] Override `login_provider_name`, `login_button`, and/or `login_description`
- [ ] Verify the login page reflects the overridden text
- [ ] Verify that removing the overrides falls back to the default translations from the message files