### PR TITLE
Bump the github-actions group with 3 updates

### DIFF
--- a/.github/workflows/php-checks.yml
+++ b/.github/workflows/php-checks.yml
@@ -48,7 +48,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -99,7 +99,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpstan-evaluate-pr.yml
+++ b/.github/workflows/phpstan-evaluate-pr.yml
@@ -19,7 +19,7 @@ jobs:
           php_extensions: zip intl gd
           command: require yiisoft/yii2-redis predis/predis simplesamlphp/simplesamlphp
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v20
         with:
           workflow: .github/workflows/phpstan-generate-baseline.yml
           workflow_conclusion: success

--- a/.github/workflows/phpstan-generate-baseline.yml
+++ b/.github/workflows/phpstan-generate-baseline.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           php vendor/bin/phpstan analyse --configuration=phpstan.neon --error-format=github --generate-baseline
       - name: Upload baseline
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: phpstan-baseline.neon
           path: phpstan-baseline.neon


### PR DESCRIPTION
Bumps the github-actions group with 3 updates: [actions/cache](https://github.com/actions/cache), [dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact) and [actions/upload-artifact](https://github.com/actions/upload-artifact).


Updates `actions/cache` from 4 to 5
- [Release notes](https://github.com/actions/cache/releases)
- [Changelog](https://github.com/actions/cache/blob/main/RELEASES.md)
- [Commits](https://github.com/actions/cache/compare/v4...v5)

Updates `dawidd6/action-download-artifact` from 6 to 20
- [Release notes](https://github.com/dawidd6/action-download-artifact/releases)
- [Commits](https://github.com/dawidd6/action-download-artifact/compare/v6...v20)

Updates `actions/upload-artifact` from 4 to 7
- [Release notes](https://github.com/actions/upload-artifact/releases)
- [Commits](https://github.com/actions/upload-artifact/compare/v4...v7)

---
updated-dependencies:
- dependency-name: actions/cache dependency-version: '5' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: dawidd6/action-download-artifact dependency-version: '20' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions
- dependency-name: actions/upload-artifact dependency-version: '7' dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions ...