### PR TITLE
Add TRUSTED_PROXIES environment variable support

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -97,7 +97,7 @@ $config = yii\helpers\ArrayHelper::merge(
                         '172.16.0.0/12',
                         '192.168.0.0/16',
                     ],
-                    $params->getTrustedProxies()
+                    $params->trustedProxies
                 ),
 
                 'parsers' => [

--- a/config/web.php
+++ b/config/web.php
@@ -91,11 +91,14 @@ $config = yii\helpers\ArrayHelper::merge(
                 'csrfCookie'          => $cookieSettings,
 
                 // Trust proxies from reverse proxies on local networks - necessary for getIsSecureConnection()
-                'trustedHosts' => [
-                    '10.0.0.0/8',
-                    '172.16.0.0/12',
-                    '192.168.0.0/16',
-                ],
+                'trustedHosts' => array_merge(
+                    [
+                        '10.0.0.0/8',
+                        '172.16.0.0/12',
+                        '192.168.0.0/16',
+                    ],
+                    $params->getTrustedProxies()
+                ),
 
                 'parsers' => [
                     'application/json' => 'yii\web\JsonParser',

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -78,6 +78,7 @@ export RANDOM_SEED=$(openssl rand -base64 32)
 | `RANDOM_SEED` | - | **Required!** Security seed: `openssl rand -base64 32` |
 | `MAIL_FROM_EMAIL` | - | Default from email |
 | `MAIL_FROM_NAME` | Antragsgrün | Default from name |
+| `TRUSTED_PROXIES` | - | Comma-separated trusted proxy IPs or CIDR ranges (e.g., `10.0.0.0/8,172.16.0.0/12`). Added to the default trusted hosts. |
 
 ## Optional Tool Paths
 

--- a/models/settings/AntragsgruenApp.php
+++ b/models/settings/AntragsgruenApp.php
@@ -93,19 +93,6 @@ class AntragsgruenApp implements \JsonSerializable
     /** @var string[] */
     public array $trustedProxies = [];
 
-    /**
-     * @return string[]
-     */
-    public function getTrustedProxies(): array
-    {
-        $envProxies = $_ENV['TRUSTED_PROXIES'] ?? '';
-        if ($envProxies !== '') {
-            return array_map('trim', explode(',', $envProxies));
-        }
-
-        return $this->trustedProxies;
-    }
-
     private function isHttps(): bool
     {
         // Needs to be equal to Yii2's web/Request.php
@@ -181,6 +168,14 @@ class AntragsgruenApp implements \JsonSerializable
             $mailConfig = EnvironmentConfigLoader::getMailServiceConfig();
             if ($mailConfig !== null) {
                 $this->mailService = $mailConfig;
+            }
+        }
+
+        // Trusted proxies configuration
+        if ($this->trustedProxies === []) {
+            $proxyConfig = EnvironmentConfigLoader::getTrustedProxiesConfig();
+            if ($proxyConfig !== null) {
+                $this->trustedProxies = $proxyConfig;
             }
         }
 

--- a/models/settings/AntragsgruenApp.php
+++ b/models/settings/AntragsgruenApp.php
@@ -90,6 +90,22 @@ class AntragsgruenApp implements \JsonSerializable
         return $app;
     }
 
+    /** @var string[] */
+    public array $trustedProxies = [];
+
+    /**
+     * @return string[]
+     */
+    public function getTrustedProxies(): array
+    {
+        $envProxies = $_ENV['TRUSTED_PROXIES'] ?? '';
+        if ($envProxies !== '') {
+            return array_map('trim', explode(',', $envProxies));
+        }
+
+        return $this->trustedProxies;
+    }
+
     private function isHttps(): bool
     {
         // Needs to be equal to Yii2's web/Request.php

--- a/models/settings/EnvironmentConfigLoader.php
+++ b/models/settings/EnvironmentConfigLoader.php
@@ -186,6 +186,47 @@ class EnvironmentConfigLoader
     }
 
     /**
+     * Get trusted proxy configuration from environment variables
+     *
+     * Supported environment variable:
+     * - TRUSTED_PROXIES: Comma-separated list of IPs or CIDR ranges
+     *   (e.g., "10.0.0.0/8,172.16.0.0/12,192.168.1.100")
+     *
+     * Each entry is validated as either a plain IP address or a CIDR notation.
+     * Invalid entries are silently skipped. Empty entries (e.g. from trailing
+     * commas) are filtered out.
+     *
+     * @return string[]|null Array of trusted proxy entries, or null if TRUSTED_PROXIES is not set
+     */
+    public static function getTrustedProxiesConfig(): ?array
+    {
+        $proxies = self::getEnv('TRUSTED_PROXIES');
+        if ($proxies === null || $proxies === '') {
+            return null;
+        }
+
+        return array_values(array_filter(
+            array_map('trim', explode(',', $proxies)),
+            fn(string $entry): bool => self::isValidTrustedProxyEntry($entry)
+        ));
+    }
+
+    /**
+     * Validate a trusted proxy entry (IP address or CIDR notation)
+     *
+     * @param string $entry IP address (e.g. "10.0.0.1") or CIDR (e.g. "10.0.0.0/8")
+     */
+    private static function isValidTrustedProxyEntry(string $entry): bool
+    {
+        if (str_contains($entry, '/')) {
+            $parts = explode('/', $entry, 2);
+            return filter_var($parts[0], FILTER_VALIDATE_IP) !== false
+                && ctype_digit($parts[1]) && (int) $parts[1] >= 0 && (int) $parts[1] <= 128;
+        }
+        return filter_var($entry, FILTER_VALIDATE_IP) !== false;
+    }
+
+    /**
      * Get application-level configuration from environment variables
      *
      * Supported environment variables:


### PR DESCRIPTION
This PR adds support for the `TRUSTED_PROXIES` environment variable to configure additional trusted proxy CIDRs.

**Problem:**
Cloud providers (Scaleway Kapsule, GKE, EKS, etc.) use non-RFC1918 internal ranges (e.g. `100.64.0.0/10` CGNAT) for pod-to-pod traffic. When a reverse proxy on these networks forwards `X-Forwarded-Proto: https`, Yii2's `Request::getIsSecureConnection()` returns false because the proxy IP isn't trusted. This breaks:
- OIDC logout/callback redirects (generates http:// instead of https:// URLs)
- Session cookie secure flag
- Any URL generation that depends on detecting HTTPS

**Solution:**
- Add `getTrustedProxies()` method to `AntragsgruenApp` that reads `TRUSTED_PROXIES` env var
- Env var format: comma-separated CIDRs (e.g. `TRUSTED_PROXIES=100.64.0.0/10,127.0.0.1`)
- Additional CIDRs are merged with existing RFC1918 defaults
- Also adds `trustedProxies` JSON property as fallback for non-container deployments

**Usage:**
```bash
TRUSTED_PROXIES=100.64.0.0/10,127.0.0.1
```

This results in trusted hosts:
- `10.0.0.0/8` (RFC1918 default)
- `172.16.0.0/12` (RFC1918 default)
- `192.168.0.0/16` (RFC1918 default)
- `100.64.0.0/10` (from env var)
- `127.0.0.1` (from env var)