### PR TITLE
Respect env var config path override

### DIFF
--- a/controllers/ManagerController.php
+++ b/controllers/ManagerController.php
@@ -44,7 +44,7 @@ class ManagerController extends Base
             return new HtmlErrorResponse(403, 'Only admins are allowed to access this page.');
         }
 
-        $configfile = $_SERVER['ANTRAGSGRUEN_CONFIG'] ?? dirname(__DIR__) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPA>
+        $configfile = $_SERVER['ANTRAGSGRUEN_CONFIG'] ?? dirname(__DIR__) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.json';
         $config     = $this->getParams();
 
         if ($config->multisiteMode) {

--- a/controllers/ManagerController.php
+++ b/controllers/ManagerController.php
@@ -44,7 +44,7 @@ class ManagerController extends Base
             return new HtmlErrorResponse(403, 'Only admins are allowed to access this page.');
         }
 
-        $configfile = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.json';
+        $configfile = $_SERVER['ANTRAGSGRUEN_CONFIG'] ?? dirname(__DIR__) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPA>
         $config     = $this->getParams();
 
         if ($config->multisiteMode) {


### PR DESCRIPTION
The antrags docs mention that a type of multisite can be implemented using SetEnvIf in the Apache config by setting "ANTRAGSGRUEN_CONFIG" with the full path to the config file for the instance domain. When loading the config on app run, the file /web.php checks this env var.

This commit makes the config management controller check this env var before defaulting to the hardcoded config location.
Without this change the following error is displayed:

<img width="400" height="188" alt="image" src="https://github.com/user-attachments/assets/44f5f26c-8f51-49c2-a66f-697734a843b8" />

and even if the default file exists and is writable, the config changes are saved to it instead of the correct file.