### PR TITLE
ci: fix dubious ownership error in phpstan evaluator

### DIFF
--- a/.github/workflows/phpstan-evaluate-pr.yml
+++ b/.github/workflows/phpstan-evaluate-pr.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: php-actions/composer@v6
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          php_version: "8.2"
-          php_extensions: zip intl gd
-      - uses: php-actions/composer@v6
-        with:
-          php_version: "8.2"
-          php_extensions: zip intl gd
-          command: require yiisoft/yii2-redis predis/predis simplesamlphp/simplesamlphp
+          php-version: '8.2'
+          extensions: zip, intl, gd
+      - name: Install Dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
+      - name: Install extra packages
+        run: composer require --no-interaction yiisoft/yii2-redis predis/predis simplesamlphp/simplesamlphp
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v21
         with:

--- a/.github/workflows/phpstan-generate-baseline.yml
+++ b/.github/workflows/phpstan-generate-baseline.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: php-actions/composer@v6
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          php_version: "8.2"
-          php_extensions: zip intl gd
-      - uses: php-actions/composer@v6
-        with:
-          php_version: "8.2"
-          php_extensions: zip intl gd
-          command: require yiisoft/yii2-redis predis/predis simplesamlphp/simplesamlphp
+          php-version: '8.2'
+          extensions: zip, intl, gd
+      - name: Install Dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
+      - name: Install extra packages
+        run: composer require --no-interaction yiisoft/yii2-redis predis/predis simplesamlphp/simplesamlphp
       - name: Generate baseline
         run: |
           php vendor/bin/phpstan analyse --configuration=phpstan.neon --error-format=github --generate-baseline


### PR DESCRIPTION
Replaces the Docker-based php-actions/composer with the native shivammathur/setup-php to avoid Git dubious ownership issues in the runner environment.