### PR TITLE
fix: make OpenTelemetry opt-in for local dev

### DIFF
--- a/docker/initialize-development-environment.sh
+++ b/docker/initialize-development-environment.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 composer install
 echo "CREATE DATABASE antragsgruen" | mysql -h mysql -u root -proot
-composer require open-telemetry/sdk open-telemetry/exporter-otlp open-telemetry/opentelemetry-auto-pdo open-telemetry/opentelemetry-auto-curl open-telemetry/opentelemetry-auto-guzzle php-http/guzzle7-adapter
+if [ "$INSTALL_OPENTELEMETRY" = "true" ]; then
+    echo "Installing OpenTelemetry dependencies..."
+    composer config --no-plugins allow-plugins.php-http/discovery true
+    composer config --no-plugins allow-plugins.tbachert/spi true
+    composer require --no-interaction open-telemetry/sdk open-telemetry/exporter-otlp open-telemetry/opentelemetry-auto-pdo open-telemetry/opentelemetry-auto-curl open-telemetry/opentelemetry-auto-guzzle php-http/guzzle7-adapter
+fi
 /var/www/antragsgruen/yii database/create-test --interactive=0


### PR DESCRIPTION
Resolves #1135. Wraps the OpenTelemetry dependencies in an if block conditioned on `INSTALL_OPENTELEMETRY=true` to prevent dirtying `composer.json` and `composer.lock` for all developers by default. Automatically allows required plugins to ensure non-interactive stability when enabled.