### PR TITLE
ci: Dormant Dependabot Auto-Merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependabot-v2-auto')
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for minor/patch
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a Dependabot auto-merge workflow that squashes and merges patch/minor dependency updates.

**How it works**: The workflow only fires when a Dependabot PR carries the `dependabot-v2-auto` label. Without that label, nothing happens. Adding the label to a Dependabot PR triggers an immediate auto-merge (squash) for semver-minor and semver-patch updates.

**Safety gate**: Works in conjunction with #1180 (acceptance test CI pipeline). #1180 includes a health gate that verifies the web app returns HTTP 200 with test data — catching catastrophic regressions (HTTP 500, DB init failures, plugin loading crashes) before any auto-merge. #1180 also fixes several infrastructure issues (DatabaseController SQL execution, composer autoload, asset permissions) that were silently broken.

**Activation**: Labels are added manually — no automatic labeling. Dormant until explicitly opted-in per PR.