### PR TITLE
Require league/oauth2-client so OIDC works out of the box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "ezyang/htmlpurifier": "^4.19.1",
     "firebase/php-jwt": "^7.0",
     "guzzlehttp/guzzle": "^8.0",
+    "league/oauth2-client": "dev-master#f16649fb5c4d2e97d3d8bcbaf54a2d2f57efdd04 as 2.9.0",
     "paragonie/sodium_compat": "^2.0",
     "phpdocumentor/reflection-docblock": "^6.0",
     "phpoffice/phpspreadsheet": "^5.0",
@@ -83,7 +84,6 @@
   "suggest": {
     "yiisoft/yii2-redis": "Allows using redis for caching",
     "simplesamlphp/simplesamlphp": "Allowed Single Sign On Authentication using SAML",
-    "league/oauth2-client": "Allows Single Sign On Authentication using OIDC",
     "predis/predis": "If simplesaml should store its data to redis",
     "open-telemetry/sdk": "OpenTelemetry SDK for OpenTelemetry integration",
     "open-telemetry/exporter-otlp": "OTLP exporter for OpenTelemetry integration",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b6a62e26339ee1733b9f7ca753a8d89",
+    "content-hash": "fc6764b3ce708a1d124370cc3e691e8e",
     "packages": [
         {
             "name": "async-aws/core",
@@ -1314,6 +1314,73 @@
                 }
             ],
             "time": "2026-07-20T13:48:31+00:00"
+        },
+        {
+            "name": "league/oauth2-client",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-client.git",
+                "reference": "f16649fb5c4d2e97d3d8bcbaf54a2d2f57efdd04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/f16649fb5c4d2e97d3d8bcbaf54a2d2f57efdd04",
+                "reference": "f16649fb5c4d2e97d3d8bcbaf54a2d2f57efdd04",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8 || ^7.8.2 || ^8.0",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.6.3 || ^3.0",
+                "php": "^7.1 || >=8.0.0 <8.6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.11"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "homepage": "https://github.com/shadowhand",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "OAuth 2.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth2",
+                "single sign on"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-client/issues",
+                "source": "https://github.com/thephpleague/oauth2-client/tree/master"
+            },
+            "time": "2026-08-03T20:32:15+00:00"
         },
         {
             "name": "league/uri",
@@ -10870,6 +10937,12 @@
     ],
     "aliases": [
         {
+            "package": "league/oauth2-client",
+            "version": "9999999-dev",
+            "alias": "2.9.0",
+            "alias_normalized": "2.9.0.0"
+        },
+        {
             "package": "s1syphos/php-simple-captcha",
             "version": "dev-main",
             "alias": "2.4.0",
@@ -10878,6 +10951,7 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "league/oauth2-client": 20,
         "s1syphos/php-simple-captcha": 20
     },
     "prefer-stable": false,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,9 +9,9 @@ parameters:
     tipsOfTheDay: false
     ignoreErrors:
       - identifier: missingType.iterableValue # Issues because Yii's ActiveRecords are recognized as Iterables
-      # Generic SSO plugin uses optional dependencies (league/oauth2-client, simplesamlphp/simplesamlphp)
+      # Generic SSO plugin uses the optional dependency simplesamlphp/simplesamlphp
       -
-          message: '#(has unknown class|on an unknown class|Instantiated class|has invalid (return |parameter )?type|Cannot import type alias) (League\\OAuth2\\Client|SimpleSAML)#'
+          message: '#(has unknown class|on an unknown class|Instantiated class|has invalid (return |parameter )?type|Cannot import type alias) SimpleSAML#'
           path: plugins/generic_sso/*
       # Yii framework generic type parameter for web application context
       -

--- a/plugins/generic_sso/OidcProvider.php
+++ b/plugins/generic_sso/OidcProvider.php
@@ -106,9 +106,12 @@ class OidcProvider
      */
     public function getAccessToken(string $code): AccessToken
     {
-        return $this->provider->getAccessToken('authorization_code', [
+        /** @var AccessToken $token */
+        $token = $this->provider->getAccessToken('authorization_code', [
             'code' => $code
         ]);
+
+        return $token;
     }
 
     /**


### PR DESCRIPTION
The generic_sso plugin's OidcProvider extends league/oauth2-client's GenericProvider, but the package is only under suggest. The dist build (composer install --no-dev) and the official Docker images therefore ship without it, so OIDC logins fatal on the missing class. This moves it to require.

SSO is the only 'real' way for most organisations to grant and revoke access, since login lives in a central identity provider. Without the library in the official images, the only option is maintaining a custom image to add one composer package and rebuilding it on every release, which is quite burdensome

league/oauth2-client is a small pure-PHP library whose only runtime dependency, guzzlehttp/guzzle, is already required, so the lockfile gains one package and no new transitive dependencies.

Before we decided to put it in 'suggest' to not bloat the image, but I think OIDC is a vital package :)