### PR TITLE
Fix SSO on the published image, and let a container configure and start itself from the environment

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -129,7 +129,12 @@ jobs:
           mkdir -p plugins runtime
           chmod 775 runtime web/assets
           
-          cp ../../plugins/*php plugins/
+          # Bundled plugins, including generic_sso, whose league/oauth2-client dependency
+          # is installed unconditionally. Copying only *.php here would ship ModuleBase.php
+          # without any of the plugin directories that extend it. Which plugins are active
+          # is decided at runtime by the "plugins" setting, not by what is packaged.
+          cp -R ../../plugins/. plugins/
+          rm -rf plugins/test_stub_*
           mv web/index-production.php web/index.php 2>/dev/null || true
           # touch config/INSTALLING # Not in Docker build
           cp config/.htaccess runtime/

--- a/commands/AppController.php
+++ b/commands/AppController.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\commands;
+
+use app\models\settings\EnvironmentConfigLoader;
+use yii\console\{Controller, ExitCode};
+
+/**
+ * @extends Controller<\yii\console\Application>
+ *
+ * Brings an installation up to the state described by its environment.
+ */
+class AppController extends Controller
+{
+    /**
+     * MySQL truncates lock names after 64 characters and treats them as a global namespace.
+     */
+    private const LOCK_NAME = 'antragsgruen.auto-init';
+
+    private const LOCK_TIMEOUT = 120;
+
+    /**
+     * Creates the database schema and the first site, if the environment asks for it.
+     *
+     * This is what the container entrypoint calls on every start, so that an image
+     * plus a set of environment variables is enough to go from an empty database to a
+     * running site - no interactive installer, no writable config.json, no one-off
+     * commands to run by hand. It does nothing at all unless AUTO_INIT is enabled, and
+     * every step it performs is idempotent, so restarts and rescheduling are harmless.
+     *
+     * Deliberately limited to *creating* what is missing: it never migrates or alters
+     * an existing schema. Upgrades stay an explicit, deliberate step.
+     */
+    public function actionAutoInit(): int
+    {
+        if (!EnvironmentConfigLoader::getBoolEnv('AUTO_INIT', false)) {
+            return ExitCode::OK;
+        }
+
+        return $this->withLock(function (): int {
+            $status = $this->runInitAction('database/init');
+            if ($status !== ExitCode::OK) {
+                return $status;
+            }
+
+            return $this->initSite();
+        });
+    }
+
+    /**
+     * Runs $callback while holding a lock shared by every instance using this database.
+     *
+     * Nothing stops several replicas from starting at once, and the "is this already
+     * there?" checks the init commands rely on are not safe against that on their own.
+     * The lock is bound to the database connection, so an instance that dies mid-init
+     * releases it instead of blocking the rest forever.
+     *
+     * @param callable(): int $callback
+     */
+    private function withLock(callable $callback): int
+    {
+        $db = \Yii::$app->db;
+
+        $acquired = $db->createCommand('SELECT GET_LOCK(:name, :timeout)', [
+            ':name' => self::LOCK_NAME,
+            ':timeout' => self::LOCK_TIMEOUT,
+        ])->queryScalar();
+
+        if (!is_scalar($acquired) || (string)$acquired !== '1') {
+            $this->stderr(
+                'Auto-init: gave up after ' . self::LOCK_TIMEOUT .
+                "s waiting for another instance to finish initializing.\n"
+            );
+            return ExitCode::TEMPFAIL;
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $db->createCommand('SELECT RELEASE_LOCK(:name)', [':name' => self::LOCK_NAME])->queryScalar();
+        }
+    }
+
+    /**
+     * Creates the first site from the environment, unless it already exists.
+     *
+     * Without SITE_ADMIN_EMAIL this does nothing, which is what a multisite
+     * installation wants: the schema is created, the sites are not.
+     */
+    private function initSite(): int
+    {
+        $email = trim((string)EnvironmentConfigLoader::getEnv('SITE_ADMIN_EMAIL', ''));
+        if ($email === '') {
+            return ExitCode::OK;
+        }
+
+        $params = [$email];
+
+        // A site cannot be created without these, and guessing either of them would put
+        // wrong information in front of users, so fail loudly instead.
+        foreach (['SITE_TITLE' => 'title', 'SITE_CONTACT' => 'contact'] as $variable => $option) {
+            $value = trim((string)EnvironmentConfigLoader::getEnv($variable, ''));
+            if ($value === '') {
+                $this->stderr('Auto-init: ' . $variable . " is required when SITE_ADMIN_EMAIL is set.\n");
+                return ExitCode::CONFIG;
+            }
+            $params[$option] = $value;
+        }
+
+        $optional = [
+            'SITE_ADMIN_PASSWORD' => 'password',
+            'SITE_ADMIN_GIVEN_NAME' => 'givenName',
+            'SITE_ADMIN_FAMILY_NAME' => 'familyName',
+            'SITE_ORGANIZATION' => 'organization',
+            'SITE_LANGUAGE' => 'language',
+            'SITE_FUNCTIONALITY' => 'functionality',
+            'SITE_LOGIN_METHODS' => 'loginMethods',
+        ];
+        foreach ($optional as $variable => $option) {
+            if (EnvironmentConfigLoader::hasEnv($variable)) {
+                $params[$option] = (string)EnvironmentConfigLoader::getEnv($variable, '');
+            }
+        }
+
+        // A password handed to the container is already as secret as the deployment can
+        // make it, so do not force a change on top of it. A generated one is printed to
+        // the log and should not survive first contact.
+        $forceChange = EnvironmentConfigLoader::getBoolEnv(
+            'SITE_FORCE_PASSWORD_CHANGE',
+            !EnvironmentConfigLoader::hasEnv('SITE_ADMIN_PASSWORD')
+        );
+        $params['forcePasswordChange'] = $forceChange ? '1' : '0';
+
+        // Superuser status is stored in config.json, which is exactly the file this is
+        // meant to make unnecessary. ADMIN_USER_IDS covers it instead. The account is
+        // still a full administrator of the site it was created with, through the
+        // regular user group.
+        $params['superuser'] = '0';
+
+        return $this->runInitAction('site/init', $params);
+    }
+
+    /**
+     * @param array<int|string, string> $params
+     */
+    private function runInitAction(string $route, array $params = []): int
+    {
+        $result = \Yii::$app->runAction($route, $params);
+
+        return is_int($result) ? $result : ExitCode::OK;
+    }
+}

--- a/commands/DatabaseController.php
+++ b/commands/DatabaseController.php
@@ -7,6 +7,7 @@ namespace app\commands;
 use app\models\db\{ISupporter, Motion, MotionSupporter, User};
 use app\models\settings\AntragsgruenApp;
 use yii\console\Controller;
+use yii\console\ExitCode;
 
 /**
  * @extends Controller<\yii\console\Application>
@@ -36,6 +37,47 @@ class DatabaseController extends Controller
             $command      = \Yii::$app->db->createCommand($deleteString);
             $command->execute();
         }
+    }
+
+    /**
+     * Initializes an empty database with the current schema.
+     *
+     * Unlike database/create this is available outside debug mode, so that containerized
+     * deployments can bootstrap a fresh database without the interactive web installer.
+     * It refuses to touch a database that already has tables, which makes it safe to run
+     * unconditionally on every container start.
+     *
+     * @throws \yii\db\Exception
+     */
+    public function actionInit(): int
+    {
+        $tablePrefix = AntragsgruenApp::getInstance()->tablePrefix;
+
+        if (in_array($tablePrefix . 'site', \Yii::$app->db->schema->getTableNames(), true)) {
+            $this->stdout('Database is already initialized, nothing to do.' . "\n");
+            return ExitCode::OK;
+        }
+
+        foreach (['create.sql', 'data.sql'] as $file) {
+            $sql = (string)file_get_contents(__DIR__ . '/../assets/db/' . $file);
+            $sql = str_replace('###TABLE_PREFIX###', $tablePrefix, $sql);
+            \Yii::$app->db->createCommand($sql)->execute();
+        }
+
+        // The web application caches table schemas for an hour, including the fact that a
+        // table does not exist yet. A container that served any request before this ran -
+        // a health check is enough - would otherwise keep reporting that the database is
+        // not set up long after it is. Schema caching is only enabled for the web
+        // application, so Schema::refresh() here would not clear it; drop the whole cache
+        // instead, which is harmless on a database that was just created.
+        $cache = \Yii::$app->has('cache') ? \Yii::$app->get('cache') : null;
+        if ($cache instanceof \yii\caching\CacheInterface) {
+            $cache->flush();
+        }
+
+        $this->stdout('Database initialized.' . "\n");
+
+        return ExitCode::OK;
     }
 
     /**

--- a/commands/SiteController.php
+++ b/commands/SiteController.php
@@ -8,6 +8,7 @@ use app\components\yii\MessageSource;
 use app\models\db\{Consultation, Site, User};
 use app\models\forms\SiteCreateForm;
 use app\models\settings\AntragsgruenApp;
+use app\models\settings\Site as SiteSettings;
 use yii\console\{Controller, ExitCode};
 
 /**
@@ -36,6 +37,13 @@ class SiteController extends Controller
      */
     public string $functionality = '1';
 
+    /**
+     * Comma-separated list of Site::LOGIN_* codes.
+     * 0=standard, 1=gruenes_netz, 3=external (SSO), 4=openslides.
+     * Defaults to the site's built-in login methods when not given.
+     */
+    public ?string $loginMethods = null;
+
     public bool $openNow = true;
     public bool $superuser = true;
     public bool $forcePasswordChange = true;
@@ -47,7 +55,7 @@ class SiteController extends Controller
             'create' => [
                 'subdomain', 'title', 'contact', 'organization', 'language',
                 'password', 'givenName', 'familyName', 'functionality',
-                'openNow', 'superuser', 'forcePasswordChange', 'force',
+                'loginMethods', 'openNow', 'superuser', 'forcePasswordChange', 'force',
             ],
             default => [],
         };
@@ -197,6 +205,15 @@ class SiteController extends Controller
             return ExitCode::SOFTWARE;
         }
         $site = $form->site;
+
+        if ($this->loginMethods !== null) {
+            $loginMethods = self::parseLoginMethods($this->loginMethods);
+            if ($loginMethods === null) {
+                $this->stderr('Invalid --loginMethods: ' . $this->loginMethods . "\n");
+                return ExitCode::USAGE;
+            }
+            self::applyLoginMethods($site, $loginMethods);
+        }
 
         $superuserPersisted = false;
         if ($this->superuser && $configFile !== null) {
@@ -421,5 +438,70 @@ class SiteController extends Controller
             $this->stdout("The user will be required to change it on first login.\n");
         }
         $this->stdout("---------------------------------------------\n");
+    }
+
+    /**
+     * Sets the login methods of an existing site.
+     *
+     * Login methods are stored inside the site's serialized settings, so without this
+     * there is no scriptable way to enable SSO logins on an already-created site.
+     *
+     * @param string $subdomain Subdomain of the site to change
+     * @param string $loginMethods Comma-separated list of Site::LOGIN_* codes,
+     *                             e.g. "0,3" for standard plus external (SSO)
+     */
+    public function actionSetLoginMethods(string $subdomain, string $loginMethods): int
+    {
+        $site = Site::findOne(['subdomain' => $subdomain]);
+        if (!$site) {
+            $this->stderr('No site found with subdomain: ' . $subdomain . "\n");
+            return ExitCode::DATAERR;
+        }
+
+        $parsed = self::parseLoginMethods($loginMethods);
+        if ($parsed === null) {
+            $this->stderr('Invalid login methods: ' . $loginMethods . "\n");
+            return ExitCode::USAGE;
+        }
+
+        self::applyLoginMethods($site, $parsed);
+        $this->stdout('Login methods of "' . $subdomain . '" set to: ' . implode(', ', $parsed) . "\n");
+
+        return ExitCode::OK;
+    }
+
+    /**
+     * @return int[]|null Parsed login method codes, or null if the input is invalid
+     */
+    private static function parseLoginMethods(string $loginMethods): ?array
+    {
+        $valid = [
+            SiteSettings::LOGIN_STD,
+            SiteSettings::LOGIN_GRUENES_NETZ,
+            SiteSettings::LOGIN_EXTERNAL,
+            SiteSettings::LOGIN_OPENSLIDES,
+        ];
+
+        $parsed = [];
+        foreach (explode(',', $loginMethods) as $method) {
+            $method = trim($method);
+            if ($method === '' || !ctype_digit($method) || !in_array((int)$method, $valid, true)) {
+                return null;
+            }
+            $parsed[] = (int)$method;
+        }
+
+        return array_values(array_unique($parsed));
+    }
+
+    /**
+     * @param int[] $loginMethods
+     */
+    private static function applyLoginMethods(Site $site, array $loginMethods): void
+    {
+        $settings = $site->getSettings();
+        $settings->loginMethods = $loginMethods;
+        $site->setSettings($settings);
+        $site->save();
     }
 }

--- a/commands/SiteController.php
+++ b/commands/SiteController.php
@@ -52,7 +52,7 @@ class SiteController extends Controller
     public function options($actionID): array
     {
         return match ($actionID) {
-            'create' => [
+            'create', 'init' => [
                 'subdomain', 'title', 'contact', 'organization', 'language',
                 'password', 'givenName', 'familyName', 'functionality',
                 'loginMethods', 'openNow', 'superuser', 'forcePasswordChange', 'force',
@@ -71,6 +71,26 @@ class SiteController extends Controller
             'l' => 'language',
             'p' => 'password',
         ];
+    }
+
+    /**
+     * Creates the site unless it already exists.
+     *
+     * Takes the same options as site/create, but is safe to run repeatedly: an existing
+     * site is left untouched and reported as success instead of an error. This is the
+     * site-level counterpart of database/init, so that a container can bootstrap itself
+     * on every start without the caller having to interpret exit codes.
+     */
+    public function actionInit(string $email): int
+    {
+        $subdomain = $this->defaultSubdomain(AntragsgruenApp::getInstance());
+
+        if ($subdomain !== null && Site::findOne(['subdomain' => $subdomain]) !== null) {
+            $this->stdout('Site "' . $subdomain . '" already exists, nothing to do.' . "\n");
+            return ExitCode::OK;
+        }
+
+        return $this->actionCreate($email);
     }
 
     /**
@@ -249,20 +269,32 @@ class SiteController extends Controller
      * Returns the validated single-label subdomain, or null on error
      * (in which case a message has already been written to stderr).
      */
+    /**
+     * The subdomain this command would act on, before any validation.
+     *
+     * In single-site mode the wizard defaults to siteSubdomain (or "std"), so mirror
+     * that here and operators rarely have to think about this label. Returns null in
+     * multisite mode, where there is no sensible default.
+     */
+    private function defaultSubdomain(AntragsgruenApp $params): ?string
+    {
+        if ($this->subdomain !== null && $this->subdomain !== '') {
+            return $this->subdomain;
+        }
+
+        return $params->multisiteMode ? null : ($params->siteSubdomain ?: 'std');
+    }
+
     private function resolveSubdomain(AntragsgruenApp $params): ?string
     {
-        $subdomain = $this->subdomain;
+        $subdomain = $this->defaultSubdomain($params);
 
-        if ($subdomain === null || $subdomain === '') {
-            // In single-site mode, the wizard defaults to siteSubdomain (or "std").
-            // Mirror that here so operators rarely have to think about this label.
-            if (!$params->multisiteMode) {
-                $subdomain = $params->siteSubdomain ?: 'std';
-                $this->stdout('Using subdomain "' . $subdomain . '" (from siteSubdomain in config.json)' . "\n");
-            } else {
-                $this->stderr("Missing required --subdomain (multisiteMode is on, no default available)\n");
-                return null;
-            }
+        if ($subdomain === null) {
+            $this->stderr("Missing required --subdomain (multisiteMode is on, no default available)\n");
+            return null;
+        }
+        if ($subdomain !== $this->subdomain) {
+            $this->stdout('Using subdomain "' . $subdomain . '" (from the siteSubdomain setting)' . "\n");
         }
 
         if (!preg_match('/^[A-Za-z0-9]([A-Za-z0-9\-]{0,61}[A-Za-z0-9])?$/siu', $subdomain)) {

--- a/components/updater/Update.php
+++ b/components/updater/Update.php
@@ -97,7 +97,6 @@ class Update
         curl_setopt($curlc, CURLOPT_RETURNTRANSFER, true);
         $resp = curl_exec($curlc);
         $info = curl_getinfo($curlc);
-        curl_close($curlc);
 
         if ($info['http_code'] !== 200 || !is_string($resp)) {
             throw new \Exception('The update could not be loaded');

--- a/components/updater/UpdateChecker.php
+++ b/components/updater/UpdateChecker.php
@@ -31,7 +31,6 @@ class UpdateChecker
         curl_setopt($curlc, CURLOPT_RETURNTRANSFER, true);
         $resp = curl_exec($curlc);
         $info = curl_getinfo($curlc);
-        curl_close($curlc);
 
         if (!in_array($info['http_code'], [200, 404])) {
             throw new Network("The updates could not be loaded");

--- a/docker/apache-single-container/Dockerfile
+++ b/docker/apache-single-container/Dockerfile
@@ -21,8 +21,11 @@ RUN mkdir -p /var/www/html \
     && tar -xjf /tmp/app.tar.bz2 --strip-components=1 -C /var/www/html \
     && rm /tmp/app.tar.bz2 \
     && rm -f /var/www/html/config/INSTALLING \
-    && mv /var/www/html/config/ /var/www/html/config-defaults/ \
-    && mkdir /var/www/html/config/
+    # config/ is shipped ready to use, so nothing has to be written at startup and the
+    # application directory can stay read-only. config-defaults/ is the same content,
+    # kept for deployments that mount config/ as a volume: there the image's files are
+    # hidden, and the entrypoint restores them from here.
+    && cp -a /var/www/html/config /var/www/html/config-defaults
 
 # Allow Static View Caches
 RUN mkdir /tmp/viewcache && chown www-data:www-data /tmp/viewcache

--- a/docker/apache-single-container/entrypoint.sh
+++ b/docker/apache-single-container/entrypoint.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+set -e
+
 # config/ is a mounted volume typically, to have config.json changes survive container rebuilds.
-# This means, that updated files in the image will be hidden. Hence, we move those files to config-defaults in the image build
-# and copy them into config/ on container startup.
+# This means, that updated files in the image will be hidden. Hence, we keep a copy of those files
+# in config-defaults in the image build and restore them into config/ on container startup.
+# Without such a volume the files are already in place and nothing is written here.
 for f in /var/www/html/config-defaults/*; do
   fname=$(basename "$f")
     target="/var/www/html/config/$fname"
@@ -14,6 +17,16 @@ for f in /var/www/html/config-defaults/*; do
     fi
 done
 
+echo "Initialized config."
 
-echo "Initialized config. Starting $@"
+# Create the database schema and the first site if AUTO_INIT asks for it; a no-op otherwise.
+# See docs/environment-variables.md. Runs as www-data so that anything it leaves behind in
+# runtime/ stays writable for the web server.
+if [ "$(id -u)" = "0" ]; then
+  setpriv --reuid=www-data --regid=www-data --clear-groups php /var/www/html/yii app/auto-init
+else
+  php /var/www/html/yii app/auto-init
+fi
+
+echo "Starting $@"
 exec "$@"

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -88,6 +88,47 @@ export RANDOM_SEED=$(openssl rand -base64 32)
 | `PLUGINS` | - | Comma-separated list of plugins to enable (e.g. `generic_sso`) |
 | `ADMIN_USER_IDS` | - | Comma-separated list of user IDs with superuser permissions |
 
+## Automatic Initialization
+
+With `AUTO_INIT` enabled, the container entrypoint brings the installation up to what the
+environment describes before starting the web server: it creates the database schema if the
+database is empty, and the first site if `SITE_ADMIN_EMAIL` is set. Both steps are skipped
+when they are already done, so this is safe on every restart.
+
+Only *missing* things are created. An existing schema is never migrated or altered, so
+upgrades remain an explicit step.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTO_INIT` | false | Create the schema and the first site on startup |
+| `SITE_ADMIN_EMAIL` | - | E-mail of the first administrator. Without it, only the schema is created |
+| `SITE_TITLE` | - | **Required** with `SITE_ADMIN_EMAIL`. Name of the site |
+| `SITE_CONTACT` | - | **Required** with `SITE_ADMIN_EMAIL`. Imprint / contact details |
+| `SITE_ADMIN_PASSWORD` | - | If unset, a password is generated and written to the container log |
+| `SITE_ADMIN_GIVEN_NAME` | - | Given name of the administrator |
+| `SITE_ADMIN_FAMILY_NAME` | - | Family name of the administrator |
+| `SITE_FORCE_PASSWORD_CHANGE` | true, unless `SITE_ADMIN_PASSWORD` is set | Require a password change on first login |
+| `SITE_ORGANIZATION` | - | Organization the site belongs to |
+| `SITE_LANGUAGE` | `BASE_LANGUAGE` | Language of the site's wording |
+| `SITE_FUNCTIONALITY` | 1 | Comma-separated feature codes: 1=motions, 2=manifesto, 3=applications, 4=agenda, 5=speech lists, 6=statute amendments, 7=votings, 8=documents |
+| `SITE_LOGIN_METHODS` | site default | Comma-separated login methods: 0=standard, 1=Grünes Netz, 3=external (SSO), 4=OpenSlides |
+
+The subdomain of the site comes from `SITE_SUBDOMAIN` (defaulting to `std`). In multisite
+mode there is no default, and sites are created with `./yii site/create` instead.
+
+The administrator created here manages its own site through the regular user group.
+Superuser permissions across all sites are granted with `ADMIN_USER_IDS`, since they are
+stored in `config.json`, which this setup is designed not to need.
+
+The same steps are available as commands, if you would rather run them yourself:
+
+```bash
+./yii database/init                    # create the schema if the database is empty
+./yii site/init admin@example.org \    # create the site if it does not exist
+    --title="My Organization" \
+    --contact="My Org, Foo Street 1, foo@example.org"
+```
+
 ## Single Sign-On (generic_sso plugin)
 
 Requires `PLUGINS` to include `generic_sso`. These variables are the equivalent of
@@ -221,6 +262,12 @@ services:
       # Multisite (optional)
       MULTISITE_MODE: "true"
       SITE_SUBDOMAIN: std
+      # Bootstrap an empty database into a running site on first start
+      AUTO_INIT: "true"
+      SITE_ADMIN_EMAIL: admin@example.com
+      SITE_ADMIN_PASSWORD: change-me
+      SITE_TITLE: "Motion Tools"
+      SITE_CONTACT: "Example Org, Foo Street 1, foo@example.com"
     ports:
       - "8080:80"
     depends_on:
@@ -244,6 +291,7 @@ When no `config.json` is present, the application will:
 1. Read all configuration from environment variables
 2. Skip the installation wizard if required variables (`DB_HOST`, `DB_NAME`, `DB_USER`, `RANDOM_SEED`) are set
 3. Auto-configure mail delivery from `MAILER_DSN` or individual `SMTP_*` variables
+4. Create the schema and the first site on startup, if `AUTO_INIT` is enabled
 
 ## Backwards Compatibility
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -111,7 +111,7 @@ upgrades remain an explicit step.
 | `SITE_ORGANIZATION` | - | Organization the site belongs to |
 | `SITE_LANGUAGE` | `BASE_LANGUAGE` | Language of the site's wording |
 | `SITE_FUNCTIONALITY` | 1 | Comma-separated feature codes: 1=motions, 2=manifesto, 3=applications, 4=agenda, 5=speech lists, 6=statute amendments, 7=votings, 8=documents |
-| `SITE_LOGIN_METHODS` | site default | Comma-separated login methods: 0=standard, 1=Grünes Netz, 3=external (SSO), 4=OpenSlides |
+| `SITE_LOGIN_METHODS` | site default | Comma-separated login methods: 0=standard, 1=Grünes Netz, 3=external (SSO) |
 
 The subdomain of the site comes from `SITE_SUBDOMAIN` (defaulting to `std`). In multisite
 mode there is no default, and sites are created with `./yii site/create` instead.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -85,6 +85,65 @@ export RANDOM_SEED=$(openssl rand -base64 32)
 | `JS_ERROR_TRACKING` | - | Target for JS Error Tracking (e.g. file:///tmp/js_errors.log or otel://) |
 | `JWT_PUBLIC_KEY` | - | Either link to public key (file:///secret/public.pem), or content of public key |
 | `JWT_PRIVATE_KEY` | - | Either link to private key (file:///secret/private.pem), or content of private key |
+| `PLUGINS` | - | Comma-separated list of plugins to enable (e.g. `generic_sso`) |
+| `ADMIN_USER_IDS` | - | Comma-separated list of user IDs with superuser permissions |
+
+## Single Sign-On (generic_sso plugin)
+
+Requires `PLUGINS` to include `generic_sso`. These variables are the equivalent of
+`config/generic_sso.json`; where both exist, the file takes precedence.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SSO_ENABLED` | false | Enables SSO. If unset, the plugin is configured from `config/generic_sso.json` only |
+| `SSO_PROTOCOL` | oidc | `oidc` or `saml` |
+| `SSO_PROVIDER_ID` | generic-sso | Identifier of the login provider |
+| `SSO_SINGLE_LOGOUT` | false | Also log out at the identity provider |
+| `SSO_SYNC_GROUPS` | false | Synchronize user groups from the identity provider |
+| `SSO_LINK_BY_EMAIL` | false | Link an existing local account on first SSO login, unless the provider reports `email_verified: false`. Only enable this if the provider verifies e-mail addresses |
+
+### OIDC
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SSO_OIDC_ISSUER` | - | Issuer URL, used for discovery and to validate the `iss` claim |
+| `SSO_OIDC_CLIENT_ID` | - | OAuth2 client ID |
+| `SSO_OIDC_CLIENT_SECRET` | - | OAuth2 client secret |
+| `SSO_OIDC_DISCOVERY` | true | Fetch endpoints from `$SSO_OIDC_ISSUER/.well-known/openid-configuration`. Explicitly set endpoints are never overwritten. The result is cached for 24 hours |
+| `SSO_OIDC_REDIRECT_URI` | auto | Defaults to the `/sso-callback` route |
+| `SSO_OIDC_URL_AUTHORIZE` | discovered | Authorization endpoint |
+| `SSO_OIDC_URL_ACCESS_TOKEN` | discovered | Token endpoint |
+| `SSO_OIDC_URL_USER_INFO` | discovered | Userinfo endpoint |
+| `SSO_OIDC_URL_LOGOUT` | discovered | End session endpoint, used by `SSO_SINGLE_LOGOUT` |
+| `SSO_OIDC_SCOPES` | openid,profile,email | Comma-separated scopes |
+| `SSO_OIDC_PKCE` | false | Use PKCE (S256) |
+| `SSO_OIDC_AUTHORIZATION_PARAMS` | - | JSON object of extra authorization request parameters, e.g. `{"prompt":"consent"}` |
+
+### SAML
+
+Only OIDC is configurable through the environment. With `SSO_PROTOCOL=saml` the
+protocol-specific settings are still read from `config/generic_sso.json`, since
+SimpleSAMLphp has to be installed and configured outside the application anyway.
+
+### Attribute mapping
+
+Defaults depend on the protocol; only set what differs from your provider.
+
+| Variable | OIDC default | SAML default |
+|----------|--------------|--------------|
+| `SSO_ATTR_EMAIL` | email | mail |
+| `SSO_ATTR_USERNAME` | preferred_username | uid |
+| `SSO_ATTR_GIVEN_NAME` | given_name | givenName |
+| `SSO_ATTR_FAMILY_NAME` | family_name | sn |
+| `SSO_ATTR_ORGANIZATION` | organization | o |
+| `SSO_ATTR_GROUPS` | groups | memberOf |
+| `SSO_GROUP_MAPPING` | - | JSON object mapping provider group names to Antragsgrün group names, e.g. `{"admins":"Admins"}` |
+
+Enabling SSO on a site additionally requires the site to allow external logins:
+
+```bash
+./yii site/set-login-methods std 0,3
+```
 
 ## Optional Tool Paths
 

--- a/models/settings/AntragsgruenApp.php
+++ b/models/settings/AntragsgruenApp.php
@@ -175,6 +175,23 @@ class AntragsgruenApp implements \JsonSerializable
             }
         }
 
+        // Enabled plugins
+        if ($this->plugins === []) {
+            $plugins = EnvironmentConfigLoader::getPluginsConfig();
+            if ($plugins !== null) {
+                /** @var array<class-string<ModuleBase>> $plugins */
+                $this->plugins = $plugins;
+            }
+        }
+
+        // Superuser accounts
+        if ($this->adminUserIds === []) {
+            $adminUserIds = EnvironmentConfigLoader::getAdminUserIdsConfig();
+            if ($adminUserIds !== null) {
+                $this->adminUserIds = $adminUserIds;
+            }
+        }
+
         // Application-level configuration
         $appConfig = EnvironmentConfigLoader::getApplicationConfig();
         foreach ($appConfig as $key => $value) {

--- a/models/settings/EnvironmentConfigLoader.php
+++ b/models/settings/EnvironmentConfigLoader.php
@@ -354,6 +354,60 @@ class EnvironmentConfigLoader
     }
 
     /**
+     * Get the list of enabled plugins from environment variables
+     *
+     * PLUGINS: comma-separated plugin directory names, e.g. "generic_sso,antragsgruen_sites"
+     *
+     * @return string[]|null Plugin names, or null if PLUGINS is not set
+     */
+    public static function getPluginsConfig(): ?array
+    {
+        if (!self::hasEnv('PLUGINS')) {
+            return null;
+        }
+
+        $plugins = [];
+        foreach (explode(',', (string)self::getEnv('PLUGINS', '')) as $plugin) {
+            $plugin = trim($plugin);
+            if ($plugin === '') {
+                continue;
+            }
+            // Plugin names become part of a class name (app\plugins\<name>\Module)
+            if (!preg_match('/^[a-zA-Z0-9_]+$/', $plugin)) {
+                continue;
+            }
+            $plugins[] = $plugin;
+        }
+
+        return $plugins === [] ? null : array_values(array_unique($plugins));
+    }
+
+    /**
+     * Get the superuser account IDs from environment variables
+     *
+     * ADMIN_USER_IDS: comma-separated user IDs, e.g. "1,2"
+     *
+     * @return int[]|null User IDs, or null if ADMIN_USER_IDS is not set
+     */
+    public static function getAdminUserIdsConfig(): ?array
+    {
+        if (!self::hasEnv('ADMIN_USER_IDS')) {
+            return null;
+        }
+
+        $userIds = [];
+        foreach (explode(',', (string)self::getEnv('ADMIN_USER_IDS', '')) as $userId) {
+            $userId = trim($userId);
+            if ($userId === '' || !ctype_digit($userId)) {
+                continue;
+            }
+            $userIds[] = (int)$userId;
+        }
+
+        return $userIds === [] ? null : array_values(array_unique($userIds));
+    }
+
+    /**
      * Get environment variable value
      *
      * Checks both $_ENV and getenv() for maximum compatibility

--- a/models/settings/EnvironmentConfigLoader.php
+++ b/models/settings/EnvironmentConfigLoader.php
@@ -416,7 +416,7 @@ class EnvironmentConfigLoader
      * @param mixed $default Default value if not set
      * @return string|null
      */
-    private static function getEnv(string $key, $default = null): ?string
+    public static function getEnv(string $key, $default = null): ?string
     {
         // Try $_ENV first (more reliable in some configurations)
         if (isset($_ENV[$key])) {
@@ -438,7 +438,7 @@ class EnvironmentConfigLoader
      * @param string $key Environment variable name
      * @return bool
      */
-    private static function hasEnv(string $key): bool
+    public static function hasEnv(string $key): bool
     {
         return isset($_ENV[$key]) || getenv($key) !== false;
     }
@@ -452,7 +452,7 @@ class EnvironmentConfigLoader
      * @param bool $default Default value
      * @return bool
      */
-    private static function getBoolEnv(string $key, bool $default): bool
+    public static function getBoolEnv(string $key, bool $default): bool
     {
         $value = self::getEnv($key);
 

--- a/plugins/generic_sso/EnvironmentConfig.php
+++ b/plugins/generic_sso/EnvironmentConfig.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace app\plugins\generic_sso;
+
+/**
+ * Builds the generic_sso configuration from environment variables.
+ *
+ * This is the environment-variable counterpart of config/generic_sso.json, so that
+ * SSO can be configured in containerized deployments without a writable config
+ * directory. The JSON file keeps precedence where both are present, mirroring the
+ * config.json > environment order documented in docs/environment-variables.md.
+ *
+ * @see docs/environment-variables.md
+ */
+class EnvironmentConfig
+{
+    private const DISCOVERY_CACHE_PREFIX = 'generic_sso.discovery.';
+    private const DISCOVERY_CACHE_TTL = 86400;
+
+    /**
+     * @return array Configuration array in generic_sso.json shape, or [] when SSO is not configured via environment.
+     */
+    public static function load(): array
+    {
+        if (!self::hasEnv('SSO_ENABLED')) {
+            return [];
+        }
+
+        $protocol = strtolower(trim((string)self::getEnv('SSO_PROTOCOL', 'oidc')));
+        if (!in_array($protocol, ['oidc', 'saml'], true)) {
+            \Yii::error('Generic SSO: unsupported SSO_PROTOCOL "' . $protocol . '", falling back to oidc');
+            $protocol = 'oidc';
+        }
+
+        $config = [
+            'enabled' => self::getBoolEnv('SSO_ENABLED', false),
+            'protocol' => $protocol,
+            'singleLogout' => self::getBoolEnv('SSO_SINGLE_LOGOUT', false),
+            'syncGroups' => self::getBoolEnv('SSO_SYNC_GROUPS', false),
+            'linkByEmail' => self::getBoolEnv('SSO_LINK_BY_EMAIL', false),
+        ];
+
+        if (self::hasEnv('SSO_PROVIDER_ID')) {
+            $config['providerId'] = self::getEnv('SSO_PROVIDER_ID');
+        }
+
+        // SAML-specific settings still come from config/generic_sso.json: SimpleSAMLphp
+        // is configured outside the application anyway, so there is little to gain from
+        // moving only half of it into the environment.
+        if ($protocol === 'oidc') {
+            $config['oidc'] = self::getOidcConfig();
+        }
+
+        $attributeMapping = self::getAttributeMapping();
+        if ($attributeMapping !== []) {
+            $config['attributeMapping'] = $attributeMapping;
+        }
+
+        $groupMapping = self::getJsonEnv('SSO_GROUP_MAPPING');
+        if ($groupMapping !== null) {
+            $config['groupMapping'] = $groupMapping;
+        }
+
+        return $config;
+    }
+
+    private static function getOidcConfig(): array
+    {
+        $oidc = [];
+
+        $stringKeys = [
+            'SSO_OIDC_CLIENT_ID' => 'clientId',
+            'SSO_OIDC_CLIENT_SECRET' => 'clientSecret',
+            'SSO_OIDC_REDIRECT_URI' => 'redirectUri',
+            'SSO_OIDC_ISSUER' => 'issuer',
+            'SSO_OIDC_URL_AUTHORIZE' => 'urlAuthorize',
+            'SSO_OIDC_URL_ACCESS_TOKEN' => 'urlAccessToken',
+            'SSO_OIDC_URL_USER_INFO' => 'urlUserInfo',
+            'SSO_OIDC_URL_LOGOUT' => 'urlLogout',
+        ];
+        foreach ($stringKeys as $env => $key) {
+            if (self::hasEnv($env)) {
+                $oidc[$key] = (string)self::getEnv($env);
+            }
+        }
+
+        if (self::hasEnv('SSO_OIDC_SCOPES')) {
+            $oidc['scopes'] = self::getListEnv('SSO_OIDC_SCOPES');
+        }
+        if (self::hasEnv('SSO_OIDC_PKCE')) {
+            $oidc['pkce'] = self::getBoolEnv('SSO_OIDC_PKCE', false);
+        }
+        $authorizationParams = self::getJsonEnv('SSO_OIDC_AUTHORIZATION_PARAMS');
+        if ($authorizationParams !== null) {
+            $oidc['authorizationParams'] = $authorizationParams;
+        }
+
+        // Fill in whatever the issuer's discovery document provides, without overriding
+        // endpoints that were set explicitly. discover() also returns jwks_uri and
+        // scopes_supported, which are not configuration keys, so only take the endpoints.
+        $issuer = $oidc['issuer'] ?? null;
+        if ($issuer !== null && $issuer !== '' && self::getBoolEnv('SSO_OIDC_DISCOVERY', true)) {
+            $discovered = self::discover($issuer);
+            $endpointKeys = ['urlAuthorize', 'urlAccessToken', 'urlUserInfo', 'urlResourceOwnerDetails', 'urlLogout'];
+            foreach ($endpointKeys as $key) {
+                $value = $discovered[$key] ?? '';
+                if ($value !== '' && (!isset($oidc[$key]) || $oidc[$key] === '')) {
+                    $oidc[$key] = $value;
+                }
+            }
+        }
+
+        // GenericProvider insists on urlResourceOwnerDetails; urlUserInfo is the name the
+        // OIDC spec uses, so accept either and keep both populated.
+        if (!isset($oidc['urlResourceOwnerDetails']) && isset($oidc['urlUserInfo'])) {
+            $oidc['urlResourceOwnerDetails'] = $oidc['urlUserInfo'];
+        }
+
+        return $oidc;
+    }
+
+    private static function getAttributeMapping(): array
+    {
+        $mapping = [];
+
+        $keys = [
+            'SSO_ATTR_EMAIL' => 'email',
+            'SSO_ATTR_USERNAME' => 'username',
+            'SSO_ATTR_GIVEN_NAME' => 'givenName',
+            'SSO_ATTR_FAMILY_NAME' => 'familyName',
+            'SSO_ATTR_ORGANIZATION' => 'organization',
+            'SSO_ATTR_GROUPS' => 'groups',
+        ];
+        foreach ($keys as $env => $key) {
+            if (self::hasEnv($env)) {
+                $mapping[$key] = (string)self::getEnv($env);
+            }
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * The login provider is instantiated per request, so an uncached discovery request
+     * would add a round trip to the identity provider on every page load.
+     */
+    private static function discover(string $issuer): array
+    {
+        $cacheKey = self::DISCOVERY_CACHE_PREFIX . md5($issuer);
+
+        // Yii throws when the component is not configured, and this runs during
+        // application setup, so never let caching problems break the login flow.
+        $cache = null;
+        try {
+            $component = \Yii::$app->has('cache') ? \Yii::$app->get('cache') : null;
+            if ($component instanceof \yii\caching\CacheInterface) {
+                $cache = $component;
+            }
+        } catch (\Throwable $e) {
+            $cache = null;
+        }
+
+        if ($cache !== null) {
+            $cached = $cache->get($cacheKey);
+            if (is_array($cached)) {
+                return $cached;
+            }
+        }
+
+        try {
+            $discovered = OidcProvider::discover($issuer);
+        } catch (\Throwable $e) {
+            \Yii::error('Generic SSO: OIDC discovery failed for ' . $issuer . ': ' . $e->getMessage());
+            return [];
+        }
+
+        if ($cache !== null) {
+            $cache->set($cacheKey, $discovered, self::DISCOVERY_CACHE_TTL);
+        }
+
+        return $discovered;
+    }
+
+    /**
+     * Merge environment-derived configuration with the JSON file, letting the file win.
+     */
+    public static function mergeWithFileConfig(array $envConfig, array $fileConfig): array
+    {
+        foreach ($fileConfig as $key => $value) {
+            if (is_array($value) && isset($envConfig[$key]) && is_array($envConfig[$key])) {
+                $envConfig[$key] = self::mergeWithFileConfig($envConfig[$key], $value);
+            } else {
+                $envConfig[$key] = $value;
+            }
+        }
+
+        return $envConfig;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getListEnv(string $key): array
+    {
+        $value = (string)self::getEnv($key, '');
+
+        return array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $v): bool => $v !== ''));
+    }
+
+    private static function getJsonEnv(string $key): ?array
+    {
+        if (!self::hasEnv($key)) {
+            return null;
+        }
+
+        $value = trim((string)self::getEnv($key, ''));
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            \Yii::error('Generic SSO: ' . $key . ' is not valid JSON: ' . $e->getMessage());
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private static function getEnv(string $key, ?string $default = null): ?string
+    {
+        if (isset($_ENV[$key])) {
+            return (string)$_ENV[$key];
+        }
+
+        $value = getenv($key);
+        if ($value !== false) {
+            return $value;
+        }
+
+        return $default;
+    }
+
+    private static function hasEnv(string $key): bool
+    {
+        return isset($_ENV[$key]) || getenv($key) !== false;
+    }
+
+    private static function getBoolEnv(string $key, bool $default): bool
+    {
+        $value = self::getEnv($key);
+        if ($value === null) {
+            return $default;
+        }
+
+        $value = strtolower(trim($value));
+        if (in_array($value, ['true', '1', 'yes', 'on'], true)) {
+            return true;
+        }
+        if (in_array($value, ['false', '0', 'no', 'off'], true)) {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+}

--- a/plugins/generic_sso/OidcProvider.php
+++ b/plugins/generic_sso/OidcProvider.php
@@ -198,8 +198,6 @@ class OidcProvider
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);
-        // No curl_close(): it is a no-op since PHP 8.0 and deprecated in 8.5, where
-        // Yii's error handler turns the deprecation into an exception.
 
         if ($httpCode !== 200 || !$response || !is_string($response)) {
             $errorMsg = 'Failed to discover OIDC configuration';

--- a/plugins/generic_sso/OidcProvider.php
+++ b/plugins/generic_sso/OidcProvider.php
@@ -63,32 +63,11 @@ class OidcProvider
     }
 
     /**
-     * Access PKCE code property via reflection (internal helper)
-     */
-    private function accessPkceProperty(string $operation, ?string $value = null): ?string
-    {
-        try {
-            $reflection = new \ReflectionClass($this->provider);
-            $property = $reflection->getProperty('pkceCode');
-            $property->setAccessible(true);
-
-            if ($operation === 'get') {
-                return $property->getValue($this->provider);
-            } elseif ($operation === 'set' && $value !== null) {
-                $property->setValue($this->provider, $value);
-            }
-        } catch (\Exception $e) {
-            \Yii::error("Failed to {$operation} PKCE code: " . $e->getMessage());
-        }
-        return null;
-    }
-
-    /**
      * Get the PKCE code verifier (if PKCE is enabled)
      */
     public function getPkceCode(): ?string
     {
-        return $this->accessPkceProperty('get');
+        return $this->provider->getPkceCode();
     }
 
     /**
@@ -97,7 +76,7 @@ class OidcProvider
     public function setPkceCode(?string $pkceCode): void
     {
         if ($pkceCode) {
-            $this->accessPkceProperty('set', $pkceCode);
+            $this->provider->setPkceCode($pkceCode);
         }
     }
 
@@ -219,7 +198,8 @@ class OidcProvider
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);
-        curl_close($ch);
+        // No curl_close(): it is a no-op since PHP 8.0 and deprecated in 8.5, where
+        // Yii's error handler turns the deprecation into an exception.
 
         if ($httpCode !== 200 || !$response || !is_string($response)) {
             $errorMsg = 'Failed to discover OIDC configuration';
@@ -241,6 +221,7 @@ class OidcProvider
             'urlAccessToken' => $config['token_endpoint'] ?? '',
             'urlUserInfo' => $config['userinfo_endpoint'] ?? '',
             'urlResourceOwnerDetails' => $config['userinfo_endpoint'] ?? '',
+            'urlLogout' => $config['end_session_endpoint'] ?? '',
             'jwks_uri' => $config['jwks_uri'] ?? '',
             'scopes_supported' => $config['scopes_supported'] ?? ['openid', 'profile', 'email'],
         ];

--- a/plugins/generic_sso/SsoLogin.php
+++ b/plugins/generic_sso/SsoLogin.php
@@ -33,23 +33,32 @@ class SsoLogin implements LoginProviderInterface
     }
 
     /**
-     * Load configuration from config file
+     * Load configuration from config file and/or environment variables.
+     *
+     * Where both are present the file wins, matching the config.json > environment
+     * precedence documented in docs/environment-variables.md.
      */
     private function loadConfiguration(): array
     {
         $configFile = __DIR__ . '/../../config/generic_sso.json';
+        $envConfig = EnvironmentConfig::load();
 
         if (!file_exists($configFile)) {
-            return self::DEFAULT_CONFIG;
+            return $envConfig !== [] ? $envConfig : self::DEFAULT_CONFIG;
         }
 
         try {
-            $config = json_decode((string)file_get_contents($configFile), true, 512, JSON_THROW_ON_ERROR);
-            return $config;
+            $fileConfig = json_decode((string)file_get_contents($configFile), true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             \Yii::error('Generic SSO: Invalid configuration file: ' . $e->getMessage());
-            return self::DEFAULT_CONFIG;
+            return $envConfig !== [] ? $envConfig : self::DEFAULT_CONFIG;
         }
+
+        if (!is_array($fileConfig)) {
+            return $envConfig !== [] ? $envConfig : self::DEFAULT_CONFIG;
+        }
+
+        return $envConfig !== [] ? EnvironmentConfig::mergeWithFileConfig($envConfig, $fileConfig) : $fileConfig;
     }
 
     public function getId(): string

--- a/plugins/generic_sso/SsoLogin.php
+++ b/plugins/generic_sso/SsoLogin.php
@@ -312,6 +312,12 @@ class SsoLogin implements LoginProviderInterface
             throw new \Exception('Could not create/update user: ' . $errors);
         }
 
+        // user.authKey is BINARY(100), so the database returns it NUL-padded. For a user
+        // created in this request the in-memory value is still unpadded, which is what
+        // would end up in the identity cookie; the next request compares that against the
+        // padded value from the database, fails, and logs the user straight out again.
+        $user->refresh();
+
         // Sync user groups if configured
         if (isset($userData['groups']) && is_array($userData['groups'])) {
             $this->syncUserGroups($user, $userData['groups']);

--- a/tests/Support/Helper/Download.php
+++ b/tests/Support/Helper/Download.php
@@ -45,7 +45,6 @@ class Download extends Module
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
         $data = curl_exec($handle);
         $info = curl_getinfo($handle);
-        curl_close($handle);
         if ($info['http_code'] !== 200) {
             throw new RuntimeException('File not found: '.$info['http_code'].' / '.$url);
         }

--- a/tests/Support/Helper/TestApi.php
+++ b/tests/Support/Helper/TestApi.php
@@ -37,7 +37,6 @@ class TestApi extends Module
 
         $data = curl_exec($handle);
         $info = curl_getinfo($handle);
-        curl_close($handle);
         if ($info['http_code'] !== 200) {
             throw new RuntimeException('File not found: '.$info['http_code'].' / '.$url);
         }


### PR DESCRIPTION
`generic_sso` does not work at the moment, two bugs break OIDC login. The rest removes the remaining reasons a container needs a writable `config.json` or hand-run SQL to start.

**Fixes**

- OIDC login fails on PHP 8.5, which the Docker images use. `curl_close()` and `setAccessible()` are deprecated there and Yii turns deprecations into exceptions, so `discover()` threw and the PKCE accessor returned `null` — every PKCE login failed with `invalid_grant`. `league/oauth2-client` exposes `getPkceCode()`/`setPkceCode()` publicly, so the reflection isn't needed.
- Users were logged out again after their first SSO login. `user.authKey` is `BINARY(100)`, so the unpadded value in the identity cookie never matches the NUL-padded one from the database. Reload the record after saving.
- The dist step restores only `plugins/*php`, so no plugin directories ship. `ghcr.io/catoth/antragsgruen:4.17.1-minimal` contains none, despite `league/oauth2-client` now being required by every install.
- The image empties `config/` and leaves the entrypoint to refill it on every start, so booting at all requires a writable application directory. Shipping those files in place allows a read-only root filesystem; `config-defaults/` still restores them when `config/` is a mounted volume.

**Additions**

Each of these is a case where a container still needs a writable `config.json` or a hand-run command to finish starting up, which is what stops one image being deployed unchanged across environments with its configuration supplied entirely by the platform.

- `PLUGINS` and `ADMIN_USER_IDS` — `site/create --superuser` already tells users to set the latter "via your environment".
- `SSO_*` mirroring `config/generic_sso.json`, OIDC only; the file still wins and the two are merged. Discovery cached for a day, as the provider is built per request.
- `AUTO_INIT` — the entrypoint creates the schema and, from the `SITE_*` variables, the first site before starting Apache. Idempotent, held under a lock so several replicas may start at once, and it only ever creates what is missing: an existing schema is never migrated. Also available as `yii database/init` and `yii site/init`, since `database/create` is debug-only and there was no non-interactive bootstrap.
- `yii site/set-login-methods` and `site/create --loginMethods` — previously only reachable by `UPDATE`ing the site's settings JSON.

Additive and off by default; `config.json` keeps precedence. Verified end to end against Dex on an image built from this branch: empty database, environment variables only, no `config.json`, through to an authenticated PKCE login.
