### PR TITLE
fix(antragsgruen_sites): allow superusers to access allsites view

### DIFF
--- a/plugins/antragsgruen_sites/controllers/ManagerController.php
+++ b/plugins/antragsgruen_sites/controllers/ManagerController.php
@@ -290,7 +290,7 @@ class ManagerController extends Base
         if (!$user) {
             return false;
         }
-        return $user->isGruenesNetzUser();
+        return $user->isGruenesNetzUser() || User::currentUserIsSuperuser();
     }
 
     public function actionAllsites(): ResponseInterface

--- a/tests/Unit/AntragsgruenSitesAccessTest.php
+++ b/tests/Unit/AntragsgruenSitesAccessTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use app\components\RequestContext;
+use app\models\db\User;
+use app\models\settings\AntragsgruenApp;
+use app\plugins\antragsgruen_sites\controllers\ManagerController;
+use Codeception\Attribute\Group;
+use Tests\Support\Helper\DBTestBase;
+
+#[Group('database')]
+class AntragsgruenSitesAccessTest extends DBTestBase
+{
+    private function callCanSeeAllSites(ManagerController $controller): bool
+    {
+        $ref = new \ReflectionMethod($controller, 'canSeeAllSites');
+        return $ref->invoke($controller);
+    }
+
+    public function testGuestCannotSeeAllSites(): void
+    {
+        RequestContext::setOverrideUser(null);
+        $controller = new ManagerController('manager', \Yii::$app);
+        $this->assertFalse($this->callCanSeeAllSites($controller));
+    }
+
+    public function testRegularUserCannotSeeAllSites(): void
+    {
+        $user = User::findOne(2);
+        $this->assertNotNull($user);
+        $this->assertFalse($user->isGruenesNetzUser());
+        
+        RequestContext::setOverrideUser($user);
+        $controller = new ManagerController('manager', \Yii::$app);
+        $this->assertFalse($this->callCanSeeAllSites($controller));
+    }
+
+    public function testGruenesNetzUserCanSeeAllSites(): void
+    {
+        $user = new User();
+        $user->auth = 'https://some-name.netzbegruener.in/';
+        $this->assertTrue($user->isGruenesNetzUser());
+
+        RequestContext::setOverrideUser($user);
+        $controller = new ManagerController('manager', \Yii::$app);
+        $this->assertTrue($this->callCanSeeAllSites($controller));
+    }
+
+    public function testSuperuserCanSeeAllSites(): void
+    {
+        $user = User::findOne(3);
+        $this->assertNotNull($user);
+        AntragsgruenApp::getInstance()->adminUserIds = [$user->id];
+
+        RequestContext::setOverrideUser($user);
+        $controller = new ManagerController('manager', \Yii::$app);
+        $this->assertTrue($this->callCanSeeAllSites($controller), 'Superusers must be allowed to see all sites');
+    }
+}


### PR DESCRIPTION
### Summary
In `antragsgruen_sites`, the master site list (`/allsites`) was previously restricted exclusively to users authenticated via Gruenes Netz (`isGruenesNetzUser()`). 

This PR allows global superusers (`User::currentUserIsSuperuser()`, e.g. configured via `adminUserIds` / `ADMIN_USER_IDS`) to access `/allsites` as well, enabling multi-tenant administration for non-Green party organizations and general deployments.

### Changes
- Updated `plugins/antragsgruen_sites/controllers/ManagerController.php::canSeeAllSites()` to check `$user->isGruenesNetzUser() || User::currentUserIsSuperuser()`.
- Added unit test `tests/Unit/AntragsgruenSitesAccessTest.php` covering guest, standard user, Gruenes Netz user, and superuser access.