### PR TITLE
ci(a11y): add automated Pa11y WCAG 2.1 AA accessibility workflow

### DIFF
--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Build frontend assets
         run: pnpm run build
 
+      - name: Generate static resource manifest
+        run: |
+          rm -Rf local/cdn/dev
+          php docs/create-static-resources.php dev
+
       - name: Install PHP dependencies
         run: >-
           composer install --no-interaction

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -141,6 +141,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run automated A11y tests
-        run: node bin/test-a11y.mjs --url=http://test.antragsgruen.test/stdparteitag/std-parteitag --threshold=50
+        run: >-
+          node bin/test-a11y.mjs
+          --url=http://test.antragsgruen.test/stdparteitag/std-parteitag
+          --url=http://test.antragsgruen.test/stdparteitag/std-parteitag/motion/321-o-zapft-is
+          --url=http://test.antragsgruen.test/stdparteitag/std-parteitag/motion/321-o-zapft-is/amendment/1
         env:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -82,9 +82,19 @@ jobs:
       - name: Start PHP built-in web server
         run: |
           php -S 127.0.0.1:8080 -t web/ &
-          sleep 3
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://127.0.0.1:8080/; then
+              echo "Server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server did not become ready within 30s"
+          exit 1
         env:
           APP_DOMAIN: 127.0.0.1:8080
 
       - name: Run automated A11y tests
         run: node bin/test-a11y.mjs --url=http://127.0.0.1:8080/ --threshold=50
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -19,10 +19,6 @@ jobs:
     name: Pa11y WCAG 2.1 AA Scans
     runs-on: ubuntu-latest
 
-    env:
-      APP_DOMAIN: test.antragsgruen.test:8080
-      APP_PROTOCOL: http
-
     services:
       mysql:
         image: mysql:latest
@@ -75,8 +71,11 @@ jobs:
       - name: Prepare test configuration and database
         run: |
           cp config/config_tests.template.json config/config.json
-          sed -i 's/32768/3306/g' config/config.json
-          sed -i 's|http://localhost:8080/index-test.php|http://test.antragsgruen.test:8080|g' config/config.json
+          cp config/config_tests.template.json config/config_tests.json
+          sed -i 's/32768/3306/g' config/config.json config/config_tests.json
+          sed -i 's|"domainPlain": *"http://localhost:8080/index-test.php"|"domainPlain": "http://test.antragsgruen.test"|' config/config_tests.json
+          sed -i 's|"domainSubdomain": *"http://localhost:8080/index-test.php"|"domainSubdomain": "http://test.antragsgruen.test/<subdomain:[\\\\w_-]+>/"|' config/config_tests.json
+          grep -n -E '"(domainPlain|domainSubdomain)"' config/config_tests.json
           echo "127.0.0.1 test.antragsgruen.test" | sudo tee -a /etc/hosts
           touch config/DEBUG
           php yii database/init
@@ -97,8 +96,8 @@ jobs:
           $_SERVER['PHP_SELF'] = '/index.php';
           require $_SERVER['DOCUMENT_ROOT'] . '/index.php';
           PHP
-          php -S 127.0.0.1:8080 -t web/ /tmp/a11y-router.php &
-          url="http://test.antragsgruen.test:8080/stdparteitag/std-parteitag"
+          sudo php -S 127.0.0.1:80 -t web/ /tmp/a11y-router.php &
+          url="http://test.antragsgruen.test/stdparteitag/std-parteitag"
           for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
             if [ "$code" = "200" ]; then
@@ -118,7 +117,7 @@ jobs:
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
           for u in "/" "/stdparteitag/std-parteitag" "/std-parteitag"; do
-            code=$(curl -s -o /tmp/a11y-probe.html -w "%{http_code}" "http://test.antragsgruen.test:8080$u" || true)
+            code=$(curl -s -o /tmp/a11y-probe.html -w "%{http_code}" "http://test.antragsgruen.test$u" || true)
             echo "== GET $u -> HTTP ${code}"
             echo "- \`GET $u\` -> HTTP ${code}" >> "$GITHUB_STEP_SUMMARY"
             if [ "$code" != "200" ]; then
@@ -128,15 +127,15 @@ jobs:
             fi
           done
           echo "----- Yii runtime log (last 150 lines) -----"
-          tail -n 150 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
+          sudo tail -n 150 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
           {
             echo ""
             echo "\`\`\`"
-            tail -n 40 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
+            sudo tail -n 40 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run automated A11y tests
-        run: node bin/test-a11y.mjs --url=http://test.antragsgruen.test:8080/stdparteitag/std-parteitag --threshold=50
+        run: node bin/test-a11y.mjs --url=http://test.antragsgruen.test/stdparteitag/std-parteitag --threshold=50
         env:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -1,0 +1,90 @@
+---
+name: Accessibility (A11y) Checks
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pa11y-scan:
+    name: Pa11y WCAG 2.1 AA Scans
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+          MYSQL_ROOT_PASSWORD: yii
+          MYSQL_PASSWORD: yii
+          MYSQL_USER: yii
+          MYSQL_DATABASE: yii
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: >-
+            curl, dom, fileinfo, iconv, intl,
+            mbstring, mysql, pdo, zip
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install JS dependencies
+        run: pnpm install
+
+      - name: Build frontend assets
+        run: pnpm run build
+
+      - name: Install PHP dependencies
+        run: >-
+          composer install --no-interaction
+          --prefer-dist --no-progress
+
+      - name: Prepare test configuration and database
+        run: |
+          cp config/config_tests.template.json config/config.json
+          sed -i 's/32768/3306/g' config/config.json
+          sed -i 's|http://localhost:8080/index-test.php|http://127.0.0.1:8080/|g' config/config.json
+          touch config/DEBUG
+          php yii database/init
+          php yii database/insert-test-data std
+        env:
+          APP_DOMAIN: 127.0.0.1:8080
+
+      - name: Start PHP built-in web server
+        run: |
+          php -S 127.0.0.1:8080 -t web/ &
+          sleep 3
+        env:
+          APP_DOMAIN: 127.0.0.1:8080
+
+      - name: Run automated A11y tests
+        run: node bin/test-a11y.mjs --url=http://127.0.0.1:8080/ --threshold=50

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -19,6 +19,10 @@ jobs:
     name: Pa11y WCAG 2.1 AA Scans
     runs-on: ubuntu-latest
 
+    env:
+      APP_DOMAIN: test.antragsgruen.test:8080
+      APP_PROTOCOL: http
+
     services:
       mysql:
         image: mysql:latest
@@ -72,29 +76,33 @@ jobs:
         run: |
           cp config/config_tests.template.json config/config.json
           sed -i 's/32768/3306/g' config/config.json
-          sed -i 's|http://localhost:8080/index-test.php|http://127.0.0.1:8080/|g' config/config.json
+          sed -i 's|http://localhost:8080/index-test.php|http://test.antragsgruen.test:8080|g' config/config.json
+          echo "127.0.0.1 test.antragsgruen.test" | sudo tee -a /etc/hosts
           touch config/DEBUG
           php yii database/init
           php yii database/insert-test-data std
-        env:
-          APP_DOMAIN: 127.0.0.1:8080
 
       - name: Start PHP built-in web server
         run: |
           php -S 127.0.0.1:8080 -t web/ &
+          url="http://test.antragsgruen.test:8080/stdparteitag/std-parteitag"
+          code=""
           for i in $(seq 1 30); do
-            if curl -fsS -o /dev/null http://127.0.0.1:8080/; then
+            code=$(curl -s -o /tmp/a11y-probe.html -w "%{http_code}" "$url" || true)
+            if [ "$code" = "200" ]; then
               echo "Server is up after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "Server did not become ready within 30s"
+          echo "Server did not become ready within 30s (last HTTP status: ${code:-none})"
+          echo "----- Response body (first 4 KB) -----"
+          head -c 4096 /tmp/a11y-probe.html 2>/dev/null || true
+          echo "----- Yii runtime log (last 100 lines) -----"
+          tail -n 100 runtime/logs/app.log 2>/dev/null || true
           exit 1
-        env:
-          APP_DOMAIN: 127.0.0.1:8080
 
       - name: Run automated A11y tests
-        run: node bin/test-a11y.mjs --url=http://127.0.0.1:8080/ --threshold=50
+        run: node bin/test-a11y.mjs --url=http://test.antragsgruen.test:8080/stdparteitag/std-parteitag --threshold=50
         env:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -84,7 +84,20 @@ jobs:
 
       - name: Start PHP built-in web server
         run: |
-          php -S 127.0.0.1:8080 -t web/ &
+          cat > /tmp/a11y-router.php <<'PHP'
+          <?php
+          // Mirrors docker/nginx/default.conf: try_files $uri $uri/ /index.php?$args;
+          $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+          $file = $_SERVER['DOCUMENT_ROOT'] . $path;
+          if ($path !== '/' && is_file($file) && pathinfo($file, PATHINFO_EXTENSION) !== 'php') {
+              return false; // let the built-in server serve static assets as-is
+          }
+          $_SERVER['SCRIPT_NAME'] = '/index.php';
+          $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . '/index.php';
+          $_SERVER['PHP_SELF'] = '/index.php';
+          require $_SERVER['DOCUMENT_ROOT'] . '/index.php';
+          PHP
+          php -S 127.0.0.1:8080 -t web/ /tmp/a11y-router.php &
           url="http://test.antragsgruen.test:8080/stdparteitag/std-parteitag"
           code=""
           for i in $(seq 1 30); do

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -99,9 +99,8 @@ jobs:
           PHP
           php -S 127.0.0.1:8080 -t web/ /tmp/a11y-router.php &
           url="http://test.antragsgruen.test:8080/stdparteitag/std-parteitag"
-          code=""
           for i in $(seq 1 30); do
-            code=$(curl -s -o /tmp/a11y-probe.html -w "%{http_code}" "$url" || true)
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || true)
             if [ "$code" = "200" ]; then
               echo "Server is up after ${i}s"
               exit 0
@@ -109,11 +108,33 @@ jobs:
             sleep 1
           done
           echo "Server did not become ready within 30s (last HTTP status: ${code:-none})"
-          echo "----- Response body (first 4 KB) -----"
-          head -c 4096 /tmp/a11y-probe.html 2>/dev/null || true
-          echo "----- Yii runtime log (last 100 lines) -----"
-          tail -n 100 runtime/logs/app.log 2>/dev/null || true
           exit 1
+
+      - name: Diagnose app response
+        if: failure()
+        run: |
+          {
+            echo "### A11y probe diagnostics"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          for u in "/" "/stdparteitag/std-parteitag" "/std-parteitag"; do
+            code=$(curl -s -o /tmp/a11y-probe.html -w "%{http_code}" "http://test.antragsgruen.test:8080$u" || true)
+            echo "== GET $u -> HTTP ${code}"
+            echo "- \`GET $u\` -> HTTP ${code}" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$code" != "200" ]; then
+              echo "----- Response body (first 2 KB) for $u -----"
+              head -c 2048 /tmp/a11y-probe.html 2>/dev/null || true
+              echo ""
+            fi
+          done
+          echo "----- Yii runtime log (last 150 lines) -----"
+          tail -n 150 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
+          {
+            echo ""
+            echo "\`\`\`"
+            tail -n 40 runtime/logs/app.log 2>/dev/null || echo "(no runtime log found)"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run automated A11y tests
         run: node bin/test-a11y.mjs --url=http://test.antragsgruen.test:8080/stdparteitag/std-parteitag --threshold=50

--- a/.github/workflows/a11y-checks.yml
+++ b/.github/workflows/a11y-checks.yml
@@ -80,7 +80,8 @@ jobs:
           sed -i 's/32768/3306/g' config/config.json config/config_tests.json
           sed -i 's|"domainPlain": *"http://localhost:8080/index-test.php"|"domainPlain": "http://test.antragsgruen.test"|' config/config_tests.json
           sed -i 's|"domainSubdomain": *"http://localhost:8080/index-test.php"|"domainSubdomain": "http://test.antragsgruen.test/<subdomain:[\\\\w_-]+>/"|' config/config_tests.json
-          grep -n -E '"(domainPlain|domainSubdomain)"' config/config_tests.json
+          sed -i 's/"randomSeed": "[^"]*"/"randomSeed": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"/' config/config.json config/config_tests.json
+          grep -n -E '"(domainPlain|domainSubdomain|randomSeed)"' config/config_tests.json
           echo "127.0.0.1 test.antragsgruen.test" | sudo tee -a /etc/hosts
           touch config/DEBUG
           php yii database/init

--- a/bin/test-a11y.mjs
+++ b/bin/test-a11y.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Automated Accessibility (A11y) Test Runner for Antragsgrün
+ *
+ * Runs Pa11y (WCAG 2.1 AA with HTML CodeSniffer and Axe runners) against
+ * configured application endpoints.
+ *
+ * Usage:
+ *   node bin/test-a11y.mjs
+ *   node bin/test-a11y.mjs --url=http://localhost:12380/
+ *   node bin/test-a11y.mjs --threshold=5
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pa11y from 'pa11y';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+
+// Parse CLI flags
+const args = process.argv.slice(2);
+let customUrl = null;
+let threshold = 0;
+
+for (const arg of args) {
+  if (arg.startsWith('--url=')) {
+    customUrl = arg.slice(arg.indexOf('=') + 1);
+  } else if (arg.startsWith('--threshold=')) {
+    threshold = parseInt(arg.slice(arg.indexOf('=') + 1), 10) || 0;
+  }
+}
+
+// Load pa11y.json configuration if present
+const configPath = path.join(rootDir, 'pa11y.json');
+let config = {
+  standard: 'WCAG2AA',
+  runners: ['htmlcs', 'axe'],
+  timeout: 30000,
+  wait: 500,
+  chromeLaunchConfig: {
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  },
+};
+
+if (fs.existsSync(configPath)) {
+  try {
+    const loaded = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    config = { ...config, ...loaded };
+  } catch (e) {
+    console.warn(`[a11y] Warning: Could not parse pa11y.json: ${e.message}`);
+  }
+}
+
+const targetUrls = customUrl
+  ? [customUrl]
+  : [
+      process.env.A11Y_BASE_URL || 'http://localhost:12380/',
+    ];
+
+console.log(`\n🔍 Running Automated A11y (WCAG 2.1 AA) Scans...\n`);
+
+let totalErrors = 0;
+
+for (const url of targetUrls) {
+  console.log(`Scanning: ${url}`);
+  try {
+    const results = await pa11y(url, config);
+    const errors = results.issues.filter((i) => i.type === 'error');
+    const warnings = results.issues.filter((i) => i.type === 'warning');
+    const notices = results.issues.filter((i) => i.type === 'notice');
+
+    console.log(`  → Errors: ${errors.length}, Warnings: ${warnings.length}, Notices: ${notices.length}`);
+
+    if (errors.length > 0) {
+      totalErrors += errors.length;
+      for (const err of errors.slice(0, 10)) {
+        console.log(`    ❌ [${err.code}] ${err.message} (${err.selector})`);
+      }
+      if (errors.length > 10) {
+        console.log(`    ... and ${errors.length - 10} more issues.`);
+      }
+    }
+  } catch (err) {
+    console.error(`  ❌ Scan failed on ${url}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+console.log(`\n═══════════════════════════════════════════════════════════════`);
+console.log(`Total A11y Errors: ${totalErrors} (Threshold: ${threshold})`);
+console.log(`═══════════════════════════════════════════════════════════════\n`);
+
+if (totalErrors > threshold) {
+  console.error(`❌ A11y validation failed with ${totalErrors} errors (exceeded threshold of ${threshold}).`);
+  process.exit(1);
+} else {
+  console.log(`✅ A11y validation passed!`);
+  process.exit(0);
+}

--- a/bin/test-a11y.mjs
+++ b/bin/test-a11y.mjs
@@ -9,6 +9,7 @@
  * Usage:
  *   node bin/test-a11y.mjs
  *   node bin/test-a11y.mjs --url=http://localhost:12380/
+ *   node bin/test-a11y.mjs --url=http://localhost:12380/ --url=http://localhost:12380/motion/1
  *   node bin/test-a11y.mjs --threshold=5
  */
 
@@ -20,14 +21,14 @@ import pa11y from 'pa11y';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
 
-// Parse CLI flags
+// Parse CLI flags (--url may be given multiple times)
 const args = process.argv.slice(2);
-let customUrl = null;
+const customUrls = [];
 let threshold = 0;
 
 for (const arg of args) {
   if (arg.startsWith('--url=')) {
-    customUrl = arg.slice(arg.indexOf('=') + 1);
+    customUrls.push(arg.slice(arg.indexOf('=') + 1));
   } else if (arg.startsWith('--threshold=')) {
     threshold = parseInt(arg.slice(arg.indexOf('=') + 1), 10) || 0;
   }
@@ -54,8 +55,8 @@ if (fs.existsSync(configPath)) {
   }
 }
 
-const targetUrls = customUrl
-  ? [customUrl]
+const targetUrls = customUrls.length > 0
+  ? customUrls
   : [
       process.env.A11Y_BASE_URL || 'http://localhost:12380/',
     ];

--- a/bin/test-a11y.mjs
+++ b/bin/test-a11y.mjs
@@ -41,6 +41,8 @@ let config = {
   runners: ['htmlcs', 'axe'],
   timeout: 30000,
   wait: 500,
+  levelCapWhenNeedsReview: 'warning',
+  includeWarnings: true,
   chromeLaunchConfig: {
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
   },
@@ -82,6 +84,24 @@ for (const url of targetUrls) {
       }
       if (errors.length > 10) {
         console.log(`    ... and ${errors.length - 10} more issues.`);
+      }
+    }
+
+    if (warnings.length > 0) {
+      // Warnings are mostly axe/htmlcs "needs review" items (e.g. contrast against a
+      // background image or gradient, which neither runner can compute). Grouped by
+      // rule so the list stays readable; they never affect the exit code.
+      const byRule = new Map();
+      for (const warning of warnings) {
+        const key = `${warning.runner}:${warning.code}`;
+        const entry = byRule.get(key) || { count: 0, selector: warning.selector };
+        entry.count += 1;
+        byRule.set(key, entry);
+      }
+      const sorted = [...byRule.entries()].sort((a, b) => b[1].count - a[1].count);
+      console.log(`    Warnings by rule (needs manual review, not failures):`);
+      for (const [rule, { count, selector }] of sorted) {
+        console.log(`      ⚠️  ${String(count).padStart(3)}x ${rule}  (e.g. ${selector})`);
       }
     }
   } catch (err) {

--- a/pa11y.json
+++ b/pa11y.json
@@ -1,0 +1,16 @@
+{
+  "standard": "WCAG2AA",
+  "runners": [
+    "htmlcs",
+    "axe"
+  ],
+  "timeout": 30000,
+  "wait": 500,
+  "chromeLaunchConfig": {
+    "args": [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "scripts": {
         "test:acceptance": "vendor/bin/codecept run Acceptance",
         "test:unit": "vendor/bin/codecept run Unit",
+"test:a11y": "node bin/test-a11y.mjs",
         "watch": "vite build --watch",
         "build": "vite build",
         "lint": "eslint --no-fix 'web/js/**/*.{js,ts}'",


### PR DESCRIPTION
### Summary
Adds automated accessibility (A11y) validation based on Pa11y (WCAG 2.1 AA with Axe and HTML CodeSniffer runners) to ensure political party members, delegates with visual impairments, and screen-reader users can fully participate in digital democratic processes.

### Changes
- Added `pa11y.json` configuration with WCAG 2.1 AA standard and headless Chrome sandbox settings.
- Added `bin/test-a11y.mjs` test runner: repeatable `--url` flag for scanning multiple pages in one run, `--threshold` (default: 0) and `A11Y_BASE_URL` fallback for local use. Findings that axe/htmlcs mark as "needs review" (e.g. contrast against gradients or background images, which the runners cannot compute) are capped at warning level via `levelCapWhenNeedsReview` and printed grouped by rule — visible in the log, but never failing the build.
- Added `"test:a11y": "node bin/test-a11y.mjs"` script in `package.json`.
- Added `.github/workflows/a11y-checks.yml` GitHub Action workflow (PRs + main pushes): boots MySQL and the app with the std test dataset, then scans three pages at zero-error baseline — consultation home, motion page (`motion/321-o-zapft-is`), and amendment page (`amendment/1`). Includes a diagnostics step (HTTP probes + Yii log tail) on failure.

### Notes
- The workflow overrides the test config's `randomSeed` in CI: the template's `123456` produces a 16-byte anonymous JWT signing key, which php-jwt v7 rejects (32-byte minimum for HS256), resulting in HTTP 500 on consultation pages. Proper fix for the template on main is tracked in #1257 (review item 1).
- Baseline 0 on all three pages requires the theme contrast fixes from #1268 (merged).