### PR TITLE
fix(users): scope CSV group import to consultation and support semicolon delimiters

### DIFF
--- a/components/UserGroupAdminMethods.php
+++ b/components/UserGroupAdminMethods.php
@@ -671,13 +671,13 @@ class UserGroupAdminMethods
      * @param array<string, int> $headerMap
      * @return array{processedRows: int, errors: string[]}
      */
-    public function processCsvChunk($fp, array $headerMap, string $collisionBehavior, bool $sendEmail, string $emailText): array
+    public function processCsvChunk($fp, array $headerMap, string $collisionBehavior, bool $sendEmail, string $emailText, string $delimiter = ','): array
     {
         $processedRows = 0;
         $errors = [];
         $maxRowsPerChunk = 50;
 
-        while ($processedRows < $maxRowsPerChunk && ($row = fgetcsv($fp, escape: '\\')) !== false) {
+        while ($processedRows < $maxRowsPerChunk && ($row = fgetcsv($fp, separator: $delimiter, escape: '\\')) !== false) {
             if (empty(array_filter($row))) {
                 continue; // Skip empty rows
             }
@@ -685,7 +685,7 @@ class UserGroupAdminMethods
             $processedRows++;
 
             try {
-                $email = isset($headerMap['email'], $row[$headerMap['email']]) ? trim($row[$headerMap['email']]) : '';
+                $email = isset($headerMap['email'], $row[$headerMap['email']]) ? mb_strtolower(trim($row[$headerMap['email']])) : '';
                 if ($email === '') {
                     $errors[] = 'Missing email on row.';
                     continue;
@@ -704,12 +704,18 @@ class UserGroupAdminMethods
                 $userGroups = [];
                 if (isset($headerMap['groups']) && !empty($row[$headerMap['groups']])) {
                     $groupNames = array_map('trim', explode(',', $row[$headerMap['groups']]));
+                    $availableGroups = $this->consultation->getAllAvailableUserGroups();
                     foreach ($groupNames as $groupName) {
                         if ($groupName === '') continue;
-                        $group = ConsultationUserGroup::find()
-                            ->where(['title' => $groupName])
-                            ->orWhere(['externalId' => $groupName])
-                            ->one();
+                        $group = null;
+                        foreach ($availableGroups as $availableGroup) {
+                            if (strcasecmp($availableGroup->title, $groupName) === 0 ||
+                                ($availableGroup->externalId !== null && strcasecmp($availableGroup->externalId, $groupName) === 0)
+                            ) {
+                                $group = $availableGroup;
+                                break;
+                            }
+                        }
                         if ($group) {
                             $userGroups[] = $group;
                         } else {
@@ -742,7 +748,11 @@ class UserGroupAdminMethods
                     $user->save(false);
 
                     if ($collisionBehavior === 'replace') {
-                        $user->unlinkAll('userGroups', true);
+                        $consultationGroups = $user->getUserGroupsForConsultation($this->consultation);
+                        foreach ($consultationGroups as $oldGroup) {
+                            $user->unlink('userGroups', $oldGroup, true);
+                            $this->logUserGroupRemove($user, $oldGroup);
+                        }
                         foreach ($userGroups as $group) {
                             $user->link('userGroups', $group);
                             $this->logUserGroupAdd($user, $group);
@@ -757,10 +767,10 @@ class UserGroupAdminMethods
                         }
                     }
                 } else {
-                    $auth = User::AUTH_EMAIL . ':' . mb_strtolower($email);
+                    $auth = User::AUTH_EMAIL . ':' . $email;
                     $user = new User();
                     $user->auth = $auth;
-                    $user->email = mb_strtolower($email);
+                    $user->email = $email;
                     $user->name = $name;
                     if ($firstName !== '') $user->nameGiven = $firstName;
                     if ($lastName !== '') $user->nameFamily = $lastName;

--- a/controllers/admin/UsersController.php
+++ b/controllers/admin/UsersController.php
@@ -372,7 +372,7 @@ class UsersController extends AdminBase
         $delimiter = (substr_count($cleanFirstLine, ';') > substr_count($cleanFirstLine, ',')) ? ';' : ',';
 
         $header = str_getcsv($cleanFirstLine, $delimiter, escape: '\\');
-        if (empty($header) || (count($header) === 1 && $header[0] === null)) {
+        if ($header === [null] || $header[0] === null) {
             fclose($fp);
             @unlink($filePath);
             return new JsonResponse(['success' => false, 'error' => 'File is empty.']);

--- a/controllers/admin/UsersController.php
+++ b/controllers/admin/UsersController.php
@@ -359,9 +359,22 @@ class UsersController extends AdminBase
             return new JsonResponse(['success' => false, 'error' => 'Could not open file.']);
         }
 
-        // Always read the header first to establish mappings
-        $header = fgetcsv($fp, escape: '\\');
-        if ($header === false) {
+        // Always read the header first to establish mappings and detect delimiter
+        $firstLine = fgets($fp);
+        if ($firstLine === false || trim($firstLine) === '') {
+            fclose($fp);
+            @unlink($filePath);
+            return new JsonResponse(['success' => false, 'error' => 'File is empty.']);
+        }
+
+        // Detect delimiter (; or ,) from the first line
+        $cleanFirstLine = (string) preg_replace('/^\xEF\xBB\xBF/', '', $firstLine);
+        $delimiter = (substr_count($cleanFirstLine, ';') > substr_count($cleanFirstLine, ',')) ? ';' : ',';
+
+        $header = str_getcsv($cleanFirstLine, $delimiter, escape: '\\');
+        if (empty($header) || (count($header) === 1 && $header[0] === null)) {
+            fclose($fp);
+            @unlink($filePath);
             return new JsonResponse(['success' => false, 'error' => 'File is empty.']);
         }
 
@@ -379,7 +392,7 @@ class UsersController extends AdminBase
             fseek($fp, $offset);
         }
 
-        $result = $this->userGroupAdminMethods->processCsvChunk($fp, $headerMap, $collisionBehavior, $sendEmail, $emailText);
+        $result = $this->userGroupAdminMethods->processCsvChunk($fp, $headerMap, $collisionBehavior, $sendEmail, $emailText, $delimiter);
         $nextOffset = ftell($fp);
         $finished = feof($fp) || $result['processedRows'] === 0;
 

--- a/tests/Unit/CsvUserImportTest.php
+++ b/tests/Unit/CsvUserImportTest.php
@@ -268,20 +268,138 @@ class CsvUserImportTest extends TestBase
         fclose($fp);
     }
 
-    public function testCsvWithSemicolonSeparatorUsesDefaultComma(): void
+    // ---------------------------------------------------------------
+    //  Delimiter auto-detection helpers
+    // ---------------------------------------------------------------
+
+    /**
+     * Detects delimiter (; or ,) from the first line exactly like actionProcessCsvChunk does.
+     */
+    private function detectDelimiter(string $firstLine): string
     {
-        // fgetcsv defaults to comma — semicolons won't be split
-        $csvContent = "Email;First_Name;Last_Name\nuser@test.org;Jane;Smith";
+        $cleanFirstLine = (string) preg_replace('/^\xEF\xBB\xBF/', '', $firstLine);
+        return (substr_count($cleanFirstLine, ';') > substr_count($cleanFirstLine, ',')) ? ';' : ',';
+    }
+
+    /**
+     * Parses the first line with auto-detected delimiter exactly like actionProcessCsvChunk does.
+     *
+     * @return array{delimiter: string, headerMap: array<string, int>}
+     */
+    private function parseFirstLine(string $firstLine): array
+    {
+        $cleanFirstLine = (string) preg_replace('/^\xEF\xBB\xBF/', '', $firstLine);
+        $delimiter = (substr_count($cleanFirstLine, ';') > substr_count($cleanFirstLine, ',')) ? ';' : ',';
+        $header = str_getcsv($cleanFirstLine, $delimiter, escape: '\\');
+        $header[0] = preg_replace('/^\xEF\xBB\xBF/', '', (string) $header[0]);
+        $headerMap = array_flip(
+            array_map(
+                'trim',
+                array_map(function ($v) { return strtolower((string) $v); }, $header)
+            )
+        );
+
+        return [
+            'delimiter' => $delimiter,
+            'headerMap' => $headerMap,
+        ];
+    }
+
+    public function testDelimiterDetectionWithComma(): void
+    {
+        $line = "Email,First_Name,Last_Name,Organization,Groups\n";
+        $this->assertSame(',', $this->detectDelimiter($line));
+
+        $parsed = $this->parseFirstLine($line);
+        $this->assertSame(',', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+        $this->assertArrayHasKey('first_name', $parsed['headerMap']);
+    }
+
+    public function testDelimiterDetectionWithSemicolon(): void
+    {
+        $line = "Email;First_Name;Last_Name;Organization;Groups\n";
+        $this->assertSame(';', $this->detectDelimiter($line));
+
+        $parsed = $this->parseFirstLine($line);
+        $this->assertSame(';', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+        $this->assertArrayHasKey('first_name', $parsed['headerMap']);
+        $this->assertSame(0, $parsed['headerMap']['email']);
+        $this->assertSame(1, $parsed['headerMap']['first_name']);
+    }
+
+    public function testDelimiterDetectionWithBomAndSemicolon(): void
+    {
+        $bom = "\xEF\xBB\xBF";
+        $line = $bom . "Email;First_Name;Last_Name\n";
+        $parsed = $this->parseFirstLine($line);
+
+        $this->assertSame(';', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+        $this->assertSame(0, $parsed['headerMap']['email']);
+    }
+
+    public function testDelimiterDetectionDefaultsToCommaOnSingleColumn(): void
+    {
+        $line = "Email\n";
+        $parsed = $this->parseFirstLine($line);
+
+        $this->assertSame(',', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+    }
+
+    public function testFullCsvWithSemicolonDelimiterParsing(): void
+    {
+        $csvContent = "Email;First_Name;Last_Name;Organization;Groups\nuser@test.org;Jane;Smith;Org;Admin";
         $fp = fopen('php://memory', 'r+');
         fwrite($fp, $csvContent);
         rewind($fp);
 
-        $header = fgetcsv($fp);
-        $headerMap = $this->parseHeader($header);
+        $firstLine = fgets($fp);
+        $this->assertNotFalse($firstLine);
 
-        // The entire line is treated as one column when using comma delimiter
-        $this->assertArrayNotHasKey('email', $headerMap, 'Semicolon-separated CSV should not parse correctly with default comma delimiter');
+        $parsed = $this->parseFirstLine($firstLine);
+        $this->assertSame(';', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+
+        // Read data row with detected delimiter
+        $row = fgetcsv($fp, separator: $parsed['delimiter'], escape: '\\');
+        $this->assertNotFalse($row);
+        $this->assertSame('user@test.org', $row[$parsed['headerMap']['email']]);
+        $this->assertSame('Jane', $row[$parsed['headerMap']['first_name']]);
+        $this->assertSame('Smith', $row[$parsed['headerMap']['last_name']]);
+        $this->assertSame('Org', $row[$parsed['headerMap']['organization']]);
+        $this->assertSame('Admin', $row[$parsed['headerMap']['groups']]);
 
         fclose($fp);
+    }
+
+    public function testFullCsvWithBomAndSemicolonParsing(): void
+    {
+        $bom = "\xEF\xBB\xBF";
+        $csvContent = $bom . "Email;First_Name;Last_Name\nuser@test.org;Jane;Smith";
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, $csvContent);
+        rewind($fp);
+
+        $firstLine = fgets($fp);
+        $parsed = $this->parseFirstLine($firstLine);
+
+        $this->assertSame(';', $parsed['delimiter']);
+        $this->assertArrayHasKey('email', $parsed['headerMap']);
+
+        $row = fgetcsv($fp, separator: $parsed['delimiter'], escape: '\\');
+        $this->assertSame('user@test.org', $row[$parsed['headerMap']['email']]);
+
+        fclose($fp);
+    }
+
+    public function testEmailNormalization(): void
+    {
+        $rawEmail = "  User.Name+Tag@Example.COM  \n";
+        $normalized = mb_strtolower(trim($rawEmail));
+
+        $this->assertSame('user.name+tag@example.com', $normalized);
     }
 }


### PR DESCRIPTION
### 🔍 Summary of Fixes

This PR resolves several critical edge cases and security boundaries in the CSV user import feature (`PR #1174`):

1. **Multi-Tenancy User Group Scoping**:
   - In `components/UserGroupAdminMethods.php`, user group lookups from the CSV `groups` column were previously queried globally (`ConsultationUserGroup::find()->where(['title' => $groupName])->one()`).
   - Group lookups are now strictly scoped to `$this->consultation->getAllAvailableUserGroups()` via case-insensitive `strcasecmp` on `title` and `externalId`. This prevents cross-consultation / cross-site group assignment.

2. **Scoped Unlinking on Replace**:
   - When importing users with `collisionBehavior === 'replace'`, `$user->unlinkAll('userGroups', true)` was previously wiping group memberships across all consultations and sites on the instance.
   - Now, only user groups associated with the current consultation (`$user->getUserGroupsForConsultation($this->consultation)`) are unlinked.

3. **Automatic Semicolon (`;`) Delimiter Detection**:
   - In European locales (e.g. Germany/Austria/Switzerland/Netherlands), Microsoft Excel exports CSV files with semicolon (`;`) delimiters by default.
   - `UsersController::actionProcessCsvChunk` and `UserGroupAdminMethods::processCsvChunk` now automatically detect whether `;` or `,` is used based on the header line.

4. **Email Lowercase Normalization**:
   - Normalized email lookups to `mb_strtolower(trim($email))` to ensure consistency with user account creation.

5. **Unit Tests**:
   - Added unit test coverage in `tests/Unit/CsvUserImportTest.php` verifying comma/semicolon auto-detection, BOM handling, and email normalization.